### PR TITLE
specify the absolute root to look for loaders and aliased modules - fixes #31

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -38,7 +38,15 @@ const webpackConfig = {
       }
     ]
   },
+  resolveLoader: {
+    // this is a workaround for loaders being applied
+    // to linked modules
+    root: path.join(__dirname, 'node_modules')
+  },
   resolve: {
+    // this is a workaround for aliasing a top level dependency
+    // inside a symlinked subdependency
+    root: path.join(__dirname, 'node_modules'),
     alias: {
       // replacing `fs` with a browser-compatible version
       fs: 'browserify-fs',


### PR DESCRIPTION
@jacobrosenthal can you test that this solves your issue? If so, please merge it.
