### PR TITLE
Bs2 board

### DIFF
--- a/client.js
+++ b/client.js
@@ -6,6 +6,9 @@ var app = new Irken();
 
 var plugins = [
   {
+    register: require('bs2-serial')
+  },
+  {
     register: require('frylord')
   },
   {

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -50,7 +50,8 @@ const webpackConfig = {
     alias: {
       // replacing `fs` with a browser-compatible version
       fs: 'browserify-fs',
-      memdown: 'level-js'
+      memdown: 'level-js',
+      serialport: 'browser-serialport'
     }
   },
   bail: true,

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "test"
   },
   "dependencies": {
+    "browser-serialport": "git://github.com/garrows/browser-serialport#update",
     "codemirror": "^4.13.0",
     "frylord": "^0.4.0",
     "holovisor": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "browser-serialport": "git://github.com/garrows/browser-serialport#update",
+    "bs2-serial": "jacobrosenthal/bs2-serial",
     "codemirror": "^4.13.0",
     "frylord": "^0.4.0",
     "holovisor": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "test": "test"
   },
   "dependencies": {
-    "browser-serialport": "git://github.com/garrows/browser-serialport#update",
     "bs2-serial": "jacobrosenthal/bs2-serial",
     "codemirror": "^4.13.0",
     "frylord": "^0.4.0",
@@ -24,6 +23,7 @@
     "babel-loader": "^4.0.0",
     "babelify": "^5.0.4",
     "browserify-fs": "^1.0.0",
+    "browser-serialport": "git://github.com/garrows/browser-serialport#update",
     "chalk": "^1.0.0",
     "css-loader": "^0.9.1",
     "expect": "git://github.com/phated/expect",


### PR DESCRIPTION
Add a 'board' for basic stamp. Based on non versioned https://github.com/jacobrosenthal/bs2-serial
Need to firm up a bunch there, should compile take options.sketch?
Also ideally bs2-serial should register multiple 'boards' one for each bs2 revision it knows about.
