### PR TITLE
travis deploy to github releases upon tag - ref #30

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,7 @@ node_modules
 .lock-wscript
 
 .DS_Store
+
+# Generated files
 bundle.js
+dist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,14 @@ before_install:
   - tar -xjf phantomjs-2.0.0-ubuntu-12.04.tar.bz2
   - export PATH=$PWD:$PATH
 script: npm run ci
+# whenever a tag is pushed, we deploy to github releases
+before_deploy: npm run release
+deploy:
+  provider: releases
+  api_key: $GH_TOKEN
+  file: "dist/chromeide.zip"
+  skip_cleanup: true
+  on:
+    tags: true
+    node: '0.10'
+    all_branches: true

--- a/package.json
+++ b/package.json
@@ -26,9 +26,11 @@
     "browser-serialport": "git://github.com/garrows/browser-serialport#update",
     "chalk": "^1.0.0",
     "css-loader": "^0.9.1",
+    "del": "^1.1.1",
     "expect": "git://github.com/phated/expect",
     "gulp": "git://github.com/gulpjs/gulp#4.0",
     "gulp-util": "^3.0.4",
+    "gulp-zip": "^2.0.3",
     "html-loader": "^0.2.3",
     "json-loader": "^0.5.1",
     "level-js": "^2.1.6",
@@ -41,7 +43,9 @@
   "scripts": {
     "test": "zuul test/*.js --local --open",
     "ci": "zuul test/*.js --phantom",
-    "build": "gulp"
+    "build": "gulp",
+    "release": "gulp gh-release",
+    "postinstall": "gulp postinstall"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
You can see this in action with a test release at https://github.com/parallaxinc/ChromeIDE/releases that was generated by https://travis-ci.org/parallaxinc/ChromeIDE/jobs/54801423
