### PR TITLE
add permission for unlimited storage - closes #56

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,8 @@
   "manifest_version": 2,
   "default_locale": "en",
   "permissions": [
-    "serial"
+    "serial",
+    "unlimitedStorage"
   ],
   "icons": {
     "16": "icons/icon16.png",


### PR DESCRIPTION
#### What's this PR do?

Adds `unlimitedStorage` permission to the application.
#### Where should the reviewer start?

`manifest.json`
#### How should this be manually tested?

Generate over 5mb of data in the application, I guess.  There are no Chrome warnings for this permission.
#### Any background context you want to provide?

@PropGit opened a question about the size restrictions, unlimited storage permission removes them.
#### What are the relevant tickets?
#56
