### PR TITLE
add dedupe plugin and source maps for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,6 @@ node_modules
 .DS_Store
 
 # Generated files
-bundle.js
-dist/
+/bundle.js
+/bundle.js.map
+/dist/

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,9 +2,12 @@
 
 var path = require('path');
 
+var webpack = require('webpack');
+
 var shouldWatch = (process.argv.indexOf('--watch') !== -1);
 
 module.exports = {
+  devtool: 'source-map',
   entry: './client.js',
   output: {
     path: __dirname,
@@ -39,6 +42,9 @@ module.exports = {
       }
     ]
   },
+  plugins: [
+    new webpack.optimize.DedupePlugin()
+  ],
   resolveLoader: {
     // this is a workaround for loaders being applied
     // to linked modules


### PR DESCRIPTION
#### What's this PR do?

Adds the dedupe plugin to reduce file size of `bundle.js` to 3.9mb from 5mb.  Also, adds source map generation for development.
#### Where should the reviewer start?

Pull down the changes and rebuild the application.
#### How should this be manually tested?

Test the features are still working when dependencies are deduped.
#### Any background context you want to provide?

I thought it would be a good idea to reduce file size before this release.
#### What are the relevant tickets?

None.
