### PR TITLE
Throttle html refresh events for better performance under load

### DIFF
--- a/plugins/editor/index.js
+++ b/plugins/editor/index.js
@@ -31,7 +31,7 @@ function editor(app, opts, done){
   function output(evt){
     buffer.update(evt);
 
-    if(refreshQueued){
+    if(refreshQueued != null){
       return;
     }
     if(lastRefresh < Date.now() - refreshDelayMillis){
@@ -55,6 +55,11 @@ function editor(app, opts, done){
     if(outputConsole){
       outputConsole.innerHTML = buffer.getConsoleHTML();
     }
+    if(refreshQueued != null){
+      clearInterval(refreshQueued);
+      refreshQueued = null;
+    }
+    lastRefresh = 0;
   }
 
   output.clear = clearOutput;

--- a/plugins/editor/index.js
+++ b/plugins/editor/index.js
@@ -22,14 +22,32 @@ function editor(app, opts, done){
   var outputConsole;
   var buffer = new ConsoleBuffer();
 
+  var refreshQueued = null;
+  var lastRefresh = 0;
+  var refreshDelayMillis = 64;
+
   var space = app.workspace;
 
   function output(evt){
     buffer.update(evt);
+
+    if(refreshQueued){
+      return;
+    }
+    if(lastRefresh < Date.now() - refreshDelayMillis){
+      refreshConsole();
+    }else{
+      refreshQueued = setTimeout(refreshConsole, refreshDelayMillis);
+    }
+  }
+
+  function refreshConsole(){
     if(outputConsole){
       outputConsole.innerHTML = buffer.getConsoleHTML();
       outputConsole.scrollTop = outputConsole.scrollHeight;
     }
+    refreshQueued = null;
+    lastRefresh = Date.now();
   }
 
   function clearOutput(){


### PR DESCRIPTION
#### What's this PR do?

This PR rate-limits the expensive HTML update portion of console output. Currently, if data events arrive at a very high speed, the console will attempt to display each update as it comes in. With this change, we will throttle events if they occur too quickly, but ensure that a refresh will still occur within 64ms.
#### Where should the reviewer start?

Load a program with fast data output, like in parallaxinc/ChromeIDE/issues/66.
#### How should this be manually tested?

Check CPU usage before this PR, and after. Change the `Delay` values, no noticeable change in CPU usage should occur even at 1ms.
#### Any background context you want to provide?

Events are still processed immediately in console-buffer, so internal console state is not affected by this throttling.
