### PR TITLE
Close serial ports from background page when window is closed to prevent port leakage.

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,18 +1,32 @@
 'use strict';
 
+function closeSerialPorts(){
+  chrome.serial.getConnections(function(connections){
+    connections.forEach(function(connection){
+      chrome.serial.disconnect(connection.connectionId, function(){});
+    });
+  });
+}
+
 // Listens for the app launching then creates the window
 chrome.app.runtime.onLaunched.addListener(function() {
   var width = 1000;
   var height = 500;
 
-  chrome.app.window.create('index.html', {
+  var windowOpts = {
     id: 'main',
     state: 'maximized',
     bounds: {
       width: width,
       height: height,
       left: Math.round((screen.availWidth - width) / 2),
-      top: Math.round((screen.availHeight - height)/2)
+      top: Math.round((screen.availHeight - height) / 2)
     }
+  };
+
+  chrome.app.window.create('index.html', windowOpts, function(win){
+    win.onClosed.addListener(function(){
+      closeSerialPorts();
+    });
   });
 });

--- a/background.js
+++ b/background.js
@@ -1,9 +1,11 @@
 'use strict';
 
+function noop(){}
+
 function closeSerialPorts(){
   chrome.serial.getConnections(function(connections){
     connections.forEach(function(connection){
-      chrome.serial.disconnect(connection.connectionId, function(){});
+      chrome.serial.disconnect(connection.connectionId, noop);
     });
   });
 }
@@ -25,8 +27,6 @@ chrome.app.runtime.onLaunched.addListener(function() {
   };
 
   chrome.app.window.create('index.html', windowOpts, function(win){
-    win.onClosed.addListener(function(){
-      closeSerialPorts();
-    });
+    win.onClosed.addListener(closeSerialPorts);
   });
 });


### PR DESCRIPTION
#### What's this PR do?

This PR handles an edge case where closing the window would prevent the serial port from closing properly on exit.
#### Where should the reviewer start?

Download a test program, close the main window and relaunch it. Before this change the previously used port would be tied up, and could not be identified or used to download.
#### How should this be manually tested?

Verify that downloading a sketch, closing/opening the app, and attempting to identify and download will complete successfully.
#### Any background context you want to provide?

This is due to the onClose event triggering as the main app window is being torn down, and chrome serial ports cannot be closed during the teardown. This change closes those ports from the background context, which stays alive a few seconds after the window closes until all activity is finished.
#### What are the relevant tickets?

Closes #114
