### PR TITLE
Add serial blacklist to device scan.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "frylord": "^0.5.0",
     "holovisor": "^0.2.0",
     "iggins": "^0.2.1",
-    "irken": "^0.6.0",
+    "irken": "^0.6.1",
     "lodash": "^3.9.1",
     "react": "^0.13.1",
     "react-loader": "^1.2.0",

--- a/plugins/sidebar/overlays/download.js
+++ b/plugins/sidebar/overlays/download.js
@@ -92,7 +92,7 @@ class DownloadOverlay extends React.Component {
       blacklist: [
         /Bluetooth-Incoming-Port/,
         /Bluetooth-Modem/,
-        /cu\./
+        /dev\/cu\./
       ]
     };
     this.setState({ devicePath: null, searching: true });

--- a/plugins/sidebar/overlays/download.js
+++ b/plugins/sidebar/overlays/download.js
@@ -89,7 +89,7 @@ class DownloadOverlay extends React.Component {
   reloadDevices(){
     const irken = this.props.irken;
     const scanOpts = {
-      blacklist: [
+      reject: [
         /Bluetooth-Incoming-Port/,
         /Bluetooth-Modem/,
         /dev\/cu\./

--- a/plugins/sidebar/overlays/download.js
+++ b/plugins/sidebar/overlays/download.js
@@ -88,8 +88,15 @@ class DownloadOverlay extends React.Component {
 
   reloadDevices(){
     const irken = this.props.irken;
+    const scanOpts = {
+      blacklist: [
+        /Bluetooth-Incoming-Port/,
+        /Bluetooth-Modem/,
+        /cu\./
+      ]
+    };
     this.setState({ devicePath: null, searching: true });
-    irken.scanBoards()
+    irken.scanBoards(scanOpts)
       .then((devices) => this.setState({ devices: devices, searching: false }));
   }
 


### PR DESCRIPTION
#### What's this PR do?

Adds a simple serial device blacklist for the `scanBoards` call during device identification/download. Blacklist excludes redundant `cu.` entries and OSX virtual bluetooth ports.
#### Where should the reviewer start?

Connect a parallax device, open identify/download pane.
#### How should this be manually tested?

Verify `Bluetooth-Incoming-Port`, `Bluetooth-Modem`, and all `/dev/cu.*` devices are filtered out of the list.
#### Any background context you want to provide?

`Bluetooth-Incoming-Port`, `Bluetooth-Modem` are virtual serial devices that will never represent real BS2 devices. Each `/dev/cu.*` device is an alias to a `/dev/tty.*` device and is redundant in this context.
#### What are the relevant tickets?

Refs parallaxinc/ChromeIDE/issues/116
Depends on iceddev/irken/pull/14
