### PR TITLE
Focus

### DIFF
--- a/plugins/sidebar/file-operations.js
+++ b/plugins/sidebar/file-operations.js
@@ -9,6 +9,7 @@ const NewFileOverlay = require('./overlays/new-file');
 const DownloadOverlay = require('./overlays/download');
 const DeleteConfirmOverlay = require('./overlays/delete-confirm');
 const { reloadDevices } = require('../../src/actions/device.js');
+const { clearName } = require('../../src/actions/file');
 
 const styles = require('./styles');
 
@@ -66,6 +67,10 @@ const FileOperations = React.createClass({
       .tap(() => this.handleSuccess(`'${name}' deleted successfully`))
       .catch(this.handleError)
       .finally(overlay.hide);
+  },
+  escapeDialog: function() {
+    this.hideOverlay();
+    clearName();
   },
   renderOverlay: function(component){
     const overlay = this.props.overlay;
@@ -127,15 +132,15 @@ const FileOperations = React.createClass({
     this.renderOverlay(component);
   },
   componentDidMount: function(){
-    this.remove_saveFile = app.keypress(app.keypress.CTRL_S, this.saveFile);
-    this.remove_closeDialog = app.keypress(app.keypress.ESC, this.hideOverlay);
+    this.keySaveFile = app.keypress(app.keypress.CTRL_S, this.saveFile);
+    this.keyCloseDialog = app.keypress(app.keypress.ESC, this.escapeDialog);
   },
   componentWillUnmount: function(){
-    if(this.remove_saveFile) {
-     this.remove_saveFile();
+    if(this.keySaveFile) {
+     this.keySaveFile();
     }
-    if(this.remove_closeDialog) {
-     this.remove_closeDialog();
+    if(this.keyCloseDialog) {
+     this.keyCloseDialog();
     }
   },
   render: function(){

--- a/plugins/sidebar/overlays/new-file.js
+++ b/plugins/sidebar/overlays/new-file.js
@@ -20,6 +20,13 @@ class NewFileOverlay extends React.Component {
 
   }
 
+  componentDidMount() {
+    console.log('comp mountd');
+    console.log(this.refs);
+    console.log(this.refs.filename.getDOMNode());
+    this.refs.filename.getDOMNode().focus();
+  }
+
   render(){
     const { fileName } = this.props;
 
@@ -28,6 +35,7 @@ class NewFileOverlay extends React.Component {
         <h3 style={styles.overlayTitle}>Please name your file.</h3>
         <TextField
           value={fileName}
+          ref="filename"
           placeHolder="filename"
           styles={styles.textField}
           floatingLabel

--- a/plugins/sidebar/overlays/new-file.js
+++ b/plugins/sidebar/overlays/new-file.js
@@ -21,10 +21,11 @@ class NewFileOverlay extends React.Component {
   }
 
   componentDidMount() {
-    console.log('comp mountd');
-    console.log(this.refs);
-    console.log(this.refs.filename.getDOMNode());
-    this.refs.filename.getDOMNode().focus();
+    this._setFocus();
+  }
+
+  componentDidUpdate() {
+    this._setFocus();
   }
 
   render(){
@@ -48,11 +49,6 @@ class NewFileOverlay extends React.Component {
     );
   }
 
-  _onUpdateName(evt){
-    const { value } = evt.target;
-
-    updateName(value);
-  }
   _onAccept(evt){
     const { onAccept, fileName } = this.props;
 
@@ -69,6 +65,16 @@ class NewFileOverlay extends React.Component {
     if(typeof onCancel === 'function'){
       onCancel(evt);
     }
+  }
+
+  _onUpdateName(evt){
+    const { value } = evt.target;
+
+    updateName(value);
+  }
+
+  _setFocus() {
+    React.findDOMNode(this.refs.filename).getElementsByTagName('input')[0].focus();
   }
 }
 


### PR DESCRIPTION
#### What's this PR do?

Sets focus in the new file modal to the 'filename' input when creating a new file. 

Esc key will clear anything in the 'filename' input.
#### Where should the reviewer start?

Load changes, open ChromeIDE.
#### How should this be manually tested?

Click the new file button. The focus should be on the 'filename' input for you to immediately start entering text. 
Click cancel. 
Click the new file button again. The text that was previously in the input should be gone.
Enter new text.
Press the esc key.
Click the new file button again. The text that was previously in the input should be gone.
#### What are the relevant tickets?

Closes #106 
