### PR TITLE
RX/TX Bar

### DIFF
--- a/plugins/editor/baud.js
+++ b/plugins/editor/baud.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const React = require('react');
+
+const styles = require('./styles');
+
+class Baud extends React.Component {
+
+  render() {
+    const baudRate = 115200;
+
+    return (
+      <span style={styles.baud}>
+        BAUD <span style={styles.baudRate}>{baudRate}</span>
+      </span>
+    );
+  }
+}
+
+module.exports = Baud;

--- a/plugins/editor/index.js
+++ b/plugins/editor/index.js
@@ -17,10 +17,14 @@ const consoleStore = require('../../src/stores/console');
 var editorStore = require('../../src/stores/editor');
 var { handleInput } = require('../../src/actions/editor');
 
+const React = require('react');
+const TransmissionBar = require('./transmission-bar');
+
 function editor(app, opts, done){
 
   var codeEditor;
   var outputConsole;
+  var transmission;
 
   function refreshConsole(){
     const { text } = consoleStore.getState();
@@ -77,15 +81,24 @@ function editor(app, opts, done){
       });
     }
 
+
+
     if(!outputConsole){
       outputConsole = document.createElement('pre');
       outputConsole.style.height = '200px';
-      outputConsole.style.boxShadow = 'inset 0 5px 10px -5px rgba(0, 0, 0, 0.26)';
+      outputConsole.style.boxShadow = 'inset 0 5px 10px -5px rgba(0, 0, 0, 0.42)';
       outputConsole.style.backgroundColor = 'white';
       outputConsole.style.padding = '10px';
+      outputConsole.style.margin = '0';
       outputConsole.style.overflow = 'auto';
       outputConsole.style.whiteSpace = 'pre-wrap';
       el.appendChild(outputConsole);
+    }
+    if(!transmission) {
+      transmission = document.createElement('div');
+      transmission.id = 'transmission';
+      el.appendChild(transmission);
+      React.render(<TransmissionBar />, document.getElementById('transmission'));
     }
 
     cb();

--- a/plugins/editor/index.js
+++ b/plugins/editor/index.js
@@ -94,9 +94,8 @@ function editor(app, opts, done){
     }
     if(!transmission) {
       transmission = document.createElement('div');
-      transmission.id = 'transmission';
       el.appendChild(transmission);
-      React.render(<TransmissionBar />, document.getElementById('transmission'));
+      React.render(<TransmissionBar />, transmission);
     }
 
     cb();

--- a/plugins/editor/index.js
+++ b/plugins/editor/index.js
@@ -81,12 +81,10 @@ function editor(app, opts, done){
       });
     }
 
-
-
     if(!outputConsole){
       outputConsole = document.createElement('pre');
       outputConsole.style.height = '200px';
-      outputConsole.style.boxShadow = 'inset 0 5px 10px -5px rgba(0, 0, 0, 0.42)';
+      outputConsole.style.boxShadow = 'inset 0 5px 10px -5px rgba(0, 0, 0, 0.26)';
       outputConsole.style.backgroundColor = 'white';
       outputConsole.style.padding = '10px';
       outputConsole.style.margin = '0';

--- a/plugins/editor/indicators.js
+++ b/plugins/editor/indicators.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const React = require('react');
+
+const styles = require('./styles');
+
+class Indicators extends React.Component {
+
+  render() {
+    const { flashRx, flashTx } = this.props;
+
+    let indicatorRx = [styles.indicator];
+    let indicatorTx = [styles.indicator];
+    if(flashRx) {
+      indicatorRx.push(styles.rx);
+    }
+    if(flashTx) {
+      indicatorTx.push(styles.tx);
+    }
+
+    return (
+      <span style={styles.rxtx}>
+        TX<span styles={indicatorTx} />RX<span styles={indicatorRx} />
+      </span>
+    );
+  }
+}
+
+module.exports = Indicators;

--- a/plugins/editor/styles.js
+++ b/plugins/editor/styles.js
@@ -2,7 +2,8 @@
 
 const red = '#da2100';
 const green = '#159600';
-const blue = 'blue';
+const blue = 'rgb(44, 131, 216)';
+const grey = '#666666';
 
 const styles = {
   bar: {
@@ -19,7 +20,7 @@ const styles = {
     paddingLeft: 8
   },
   indicator: {
-    backgroundColor: green,
+    backgroundColor: grey,
     height: 10,
     width: 10,
     borderRadius: '100%',

--- a/plugins/editor/styles.js
+++ b/plugins/editor/styles.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const red = '#da2100';
-const green = '#159600';
 const blue = 'rgb(44, 131, 216)';
 const grey = '#666666';
 

--- a/plugins/editor/styles.js
+++ b/plugins/editor/styles.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const red = '#da2100';
+const green = '#159600';
+const blue = 'blue';
+
+const styles = {
+  bar: {
+    margin: 0,
+    height: '25px',
+    backgroundColor: '#CFD8DC'
+  },
+  baud: {
+    float: 'left',
+    padding: '3px 0px 0px 10px',
+    margin: 0
+  },
+  baudRate: {
+    paddingLeft: 8
+  },
+  indicator: {
+    backgroundColor: green,
+    height: 10,
+    width: 10,
+    borderRadius: '100%',
+    margin: '0px 10px',
+    display: 'inline-block'
+  },
+  rxtx: {
+    float: 'right',
+    paddingTop: 3
+  },
+  rx: {
+    backgroundColor: blue
+  },
+  tx: {
+    backgroundColor: red
+  }
+};
+
+module.exports = styles;

--- a/plugins/editor/transmission-bar.js
+++ b/plugins/editor/transmission-bar.js
@@ -1,35 +1,33 @@
 'use strict';
 
 const React = require('react');
+const { createContainer } = require('sovereign');
 
+const Indicators = require('./indicators');
 const styles = require('./styles');
+const transmissionStore = require('../../src/stores/transmission');
 
 class TransmissionBar extends React.Component {
 
   render() {
-    const baudRate = 115200;
-    const { rx, tx } = this.props;
-
-    let indicatorRx = [styles.indicator];
-    let indicatorTx = [styles.indicator];
-    if(rx) {
-      indicatorRx.push(styles.rx);
-    }
-    if(tx) {
-      indicatorTx.push(styles.tx);
-    }
+    const { flashRx, flashTx } = this.props;
 
     return (
       <div style={styles.bar}>
-        <span style={styles.baud}>
-          BAUD <span style={styles.baudRate}>{baudRate}</span>
-        </span>
-        <span style={styles.rxtx}>
-          TX<span styles={indicatorTx} />RX<span styles={indicatorRx} />
-        </span>
+        <Indicators flashRx={flashRx} flashTx={flashTx} />
       </div>
     );
   }
 }
 
-module.exports = TransmissionBar;
+module.exports = createContainer(TransmissionBar, {
+  getStores(){
+    return {
+      deviceStore: transmissionStore
+    };
+  },
+
+  getPropsFromStores() {
+    return transmissionStore.getState();
+  }
+});

--- a/plugins/editor/transmission-bar.js
+++ b/plugins/editor/transmission-bar.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const React = require('react');
+
+const styles = require('./styles');
+
+class TransmissionBar extends React.Component {
+
+  render() {
+    const baudRate = 115200;
+    const { rx, tx } = this.props;
+
+    let indicatorRx = [styles.indicator];
+    let indicatorTx = [styles.indicator];
+    if(rx) {
+      indicatorRx.push(styles.rx);
+    }
+    if(tx) {
+      indicatorTx.push(styles.tx);
+    }
+
+    return (
+      <div style={styles.bar}>
+        <span style={styles.baud}>
+          BAUD <span style={styles.baudRate}>{baudRate}</span>
+        </span>
+        <span style={styles.rxtx}>
+          TX<span styles={indicatorTx} />RX<span styles={indicatorRx} />
+        </span>
+      </div>
+    );
+  }
+}
+
+module.exports = TransmissionBar;

--- a/plugins/sidebar/project-operations.js
+++ b/plugins/sidebar/project-operations.js
@@ -99,10 +99,10 @@ class ProjectOperations extends React.Component {
   componentWillUnmount(){
     if(this.remove_showProjectOverlay) {
      this.remove_showProjectOverlay();
-    }; 
+    };
     if(this.remove_closeDialog) {
      this.remove_closeDialog();
-    }; 
+    };
 
   }
 

--- a/src/actions/device.js
+++ b/src/actions/device.js
@@ -7,6 +7,10 @@ class DeviceActions {
     this.dispatch({ handleSuccess, handleError });
   }
 
+  progress(value) {
+    this.dispatch(value);
+  }
+
   reloadDevices() {
     this.dispatch();
   }

--- a/src/actions/device.js
+++ b/src/actions/device.js
@@ -7,10 +7,6 @@ class DeviceActions {
     this.dispatch({ handleSuccess, handleError });
   }
 
-  progress(value) {
-    this.dispatch(value);
-  }
-
   reloadDevices() {
     this.dispatch();
   }

--- a/src/actions/transmission.js
+++ b/src/actions/transmission.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const alt = require('../alt');
+
+class TransmissionActions {
+  rx() {
+    this.dispatch();
+  }
+
+  tx() {
+    this.dispatch();
+  }
+}
+
+module.exports = alt.createActions(TransmissionActions);

--- a/src/stores/device.js
+++ b/src/stores/device.js
@@ -4,6 +4,7 @@ const alt = require('../alt');
 
 const { download, reloadDevices, updateSelected } = require('../actions/device');
 const { clearOutput, output } = require('../actions/console');
+const { rx, tx } = require('../actions/transmission');
 
 class DeviceStore {
   constructor() {
@@ -44,13 +45,16 @@ class DeviceStore {
     const board = getBoard(selectedDevice);
 
     board.removeListener('terminal', output);
+    board.removeListener('terminal', rx);
 
     board.on('progress', updateProgress.bind(this));
+    board.on('progress', tx.bind(this));
 
     board.compile(source)
       .tap(() => clearOutput())
       .then((memory) => board.bootload(memory))
       .then(() => board.on('terminal', output))
+      .then(() => board.on('terminal', rx))
       .tap(() => toast.clear())
       .tap(() => handleSuccess(`'${name}' downloaded successfully`))
       .catch(handleError)

--- a/src/stores/transmission.js
+++ b/src/stores/transmission.js
@@ -21,19 +21,22 @@ class TransmissionStore {
   }
 
   onRx() {
-      this.setState({flashRx: true});
+    const { flashDuration } = this.state;
+    this.setState({flashRx: true});
 
-      setTimeout(() => {
-        this.setState({ flashRx: false});
-      }, this.state.flashDuration);
+    setTimeout(() => {
+      this.setState({ flashRx: false});
+    }, flashDuration);
   }
 
   onTx() {
+    const { flashDuration } = this.state;
+
     this.setState({flashTx: true});
 
     setTimeout(() => {
       this.setState({ flashTx: false});
-    }, this.state.flashDuration);
+    }, flashDuration);
   }
 
 }

--- a/src/stores/transmission.js
+++ b/src/stores/transmission.js
@@ -15,28 +15,44 @@ class TransmissionStore {
     this.state = {
       flashRx: false,
       flashTx: false,
-      flashDuration: 30
+      timeoutIdRx: null,
+      timeoutIdTx: null,
+      flashDuration: 50
     };
 
   }
 
   onRx() {
-    const { flashDuration } = this.state;
+    const { flashDuration, timeoutIdRx } = this.state;
     this.setState({flashRx: true});
 
-    setTimeout(() => {
-      this.setState({ flashRx: false});
-    }, flashDuration);
+    if(!timeoutIdRx) {
+      const id = setTimeout(() => {
+        this.setState({
+          flashRx: false,
+          timeoutIdRx: null
+        });
+      }, flashDuration);
+
+      this.setState({ timeoutIdRx: id });
+    }
   }
 
   onTx() {
-    const { flashDuration } = this.state;
+    const { flashDuration, timeoutIdTx } = this.state;
 
     this.setState({flashTx: true});
 
-    setTimeout(() => {
-      this.setState({ flashTx: false});
-    }, flashDuration);
+    if(!timeoutIdTx) {
+      const id = setTimeout(() => {
+        this.setState({
+          flashTx: false,
+          timeoutIdTx: null
+        });
+      }, flashDuration);
+
+      this.setState({ timeoutIdTx: id });
+    }
   }
 
 }

--- a/src/stores/transmission.js
+++ b/src/stores/transmission.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const alt = require('../alt');
+
+const { rx, tx } = require('../actions/transmission');
+
+class TransmissionStore {
+  constructor() {
+
+    this.bindListeners({
+      onRx: rx,
+      onTx: tx
+    });
+
+    this.state = {
+      flashRx: false,
+      flashTx: false,
+      flashDuration: 30
+    };
+
+  }
+
+  onRx() {
+      this.setState({flashRx: true});
+
+      setTimeout(() => {
+        this.setState({ flashRx: false});
+      }, this.state.flashDuration);
+  }
+
+  onTx() {
+    this.setState({flashTx: true});
+
+    setTimeout(() => {
+      this.setState({ flashTx: false});
+    }, this.state.flashDuration);
+  }
+
+}
+
+TransmissionStore.config = {
+  stateKey: 'state'
+};
+
+module.exports = alt.createStore(TransmissionStore);


### PR DESCRIPTION
#### What's this PR do?

Adds a status bar for displaying transmission events between the host and serial device. RX will flash blue when data is received from the connected device. TX will flash red when data is sent to the connected device.
#### Where should the reviewer start?

Pull this branch to see the new status bar below the debug output.
#### How should this be manually tested?

Connect a BASIC Stamp. Load in some looping code. Download code to the board. Notice the red flashing TX on download. Notice the blue flashing RX as debug information is sent to the host.
#### Any background context you want to provide?

Using flux with a new transmission store. Actions are dispatched from the device store when rx/tx events are found.
#### What are the relevant tickets?

References #78
#### Screenshots (if appropriate)

![image](https://cloud.githubusercontent.com/assets/2586086/8141717/12173020-1120-11e5-9da3-07037caba8ee.png)
