### PR TITLE
File new behavior

### DIFF
--- a/plugins/editor/key-extension.js
+++ b/plugins/editor/key-extension.js
@@ -4,7 +4,7 @@ var { findNext, findPrevious } = require('../../src/actions/find');
 var { moveByScrollUpLine, moveByScrollDownLine } = require('../../src/actions/editor-move');
 var { indent } = require('../../src/actions/text-move');
 var { print } = require('../../src/actions/system');
-var { newFile, processSave } = require('../../src/actions/file');
+var { hideOverlay, newFile, processSave } = require('../../src/actions/file');
 
 const keyExtension = {
   setup: function(app) {
@@ -64,6 +64,13 @@ const keyExtension = {
         exec: (evt) => {
           evt.preventDefault();
           processSave();
+        }
+      },
+      hideOverlay: {
+        code: 'ESC',
+        exec: (evt) => {
+          evt.preventDefault();
+          hideOverlay();
         }
       }
     };

--- a/plugins/editor/key-extension.js
+++ b/plugins/editor/key-extension.js
@@ -78,7 +78,6 @@ const keyExtension = {
       for (let cmd in cmCommands) {
         const code = cmCommands[cmd].code;
         const predicate = app.keypress[code] || customPredicates[code];
-        console.log(code);
         cmCommands[cmd].removeCode = app.keypress(predicate, cmCommands[cmd].exec);
       }
     }

--- a/plugins/editor/key-extension.js
+++ b/plugins/editor/key-extension.js
@@ -4,7 +4,7 @@ var { findNext, findPrevious } = require('../../src/actions/find');
 var { moveByScrollUpLine, moveByScrollDownLine } = require('../../src/actions/editor-move');
 var { indent } = require('../../src/actions/text-move');
 var { print } = require('../../src/actions/system');
-var { processSave } = require('../../src/actions/file');
+var { newFile, processSave } = require('../../src/actions/file');
 
 const keyExtension = {
   setup: function(app) {
@@ -52,6 +52,13 @@ const keyExtension = {
           print();
         }
       },
+      newFile: {
+        code: 'CTRL_N',
+        exec: (evt) => {
+          evt.preventDefault();
+          newFile();
+        }
+      },
       save: {
         code: 'CTRL_S',
         exec: (evt) => {
@@ -61,10 +68,18 @@ const keyExtension = {
       }
     };
 
+    const customPredicates = {
+      CTRL_N: function({ ctrlKey, metaKey, keyCode }){
+          return ((ctrlKey === true || metaKey === true) && keyCode === 78);
+        }
+    };
+
     function setCodeMirrorCommands() {
       for (let cmd in cmCommands) {
         const code = cmCommands[cmd].code;
-        cmCommands[cmd].removeCode = app.keypress(app.keypress[code], cmCommands[cmd].exec);
+        const predicate = app.keypress[code] || customPredicates[code];
+        console.log(code);
+        cmCommands[cmd].removeCode = app.keypress(predicate, cmCommands[cmd].exec);
       }
     }
 

--- a/plugins/editor/key-extension.js
+++ b/plugins/editor/key-extension.js
@@ -4,6 +4,7 @@ var { findNext, findPrevious } = require('../../src/actions/find');
 var { moveByScrollUpLine, moveByScrollDownLine } = require('../../src/actions/editor-move');
 var { indent } = require('../../src/actions/text-move');
 var { print } = require('../../src/actions/system');
+var { processSave } = require('../../src/actions/file');
 
 const keyExtension = {
   setup: function(app) {
@@ -49,6 +50,13 @@ const keyExtension = {
         exec: (evt) => {
           evt.preventDefault();
           print();
+        }
+      },
+      save: {
+        code: 'CTRL_S',
+        exec: (evt) => {
+          evt.preventDefault();
+          processSave();
         }
       }
     };

--- a/plugins/sidebar/file-operations.js
+++ b/plugins/sidebar/file-operations.js
@@ -85,6 +85,24 @@ const FileOperations = React.createClass({
     const overlay = this.props.overlay;
     overlay.hide();
   },
+  newFile: function() {
+    const { workspace } = this.props;
+    workspace.current.update(() => '');
+
+    const directory = workspace.directory.deref();
+    const untitledFiles = directory.filter(x => {
+      return x.get('name').match(/untitled/);
+    });
+
+    console.log(untitledFiles);
+    untitledFiles.takeLast(x => {
+      console.log(x.get('name').match(/\d+/g));
+    });
+
+    const numUntitled = 2;
+
+    workspace.filename.update(() => `untitled${numUntitled}`);
+  },
   showCreateOverlay: function(evt){
     evt.preventDefault();
 
@@ -162,7 +180,7 @@ const FileOperations = React.createClass({
           icon="ion-compose"
           label="Save File" />
         <ChildButton
-          onClick={this.showCreateOverlay}
+          onClick={this.newFile}
           icon="ion-document"
           label="New File" />
       </Menu>

--- a/plugins/sidebar/file-operations.js
+++ b/plugins/sidebar/file-operations.js
@@ -9,7 +9,7 @@ const NewFileOverlay = require('./overlays/new-file');
 const DownloadOverlay = require('./overlays/download');
 const DeleteConfirmOverlay = require('./overlays/delete-confirm');
 const { reloadDevices } = require('../../src/actions/device.js');
-const { clearName, newFile, processSave } = require('../../src/actions/file');
+const { clearName, deleteFile, newFile, processSave } = require('../../src/actions/file');
 
 const styles = require('./styles');
 
@@ -25,19 +25,6 @@ const FileOperations = React.createClass({
     const toast = this.props.toast;
 
     toast.show(msg, { style: styles.successToast, timeout: 5000 });
-  },
-  deleteFile: function(name){
-    const space = this.props.workspace;
-    const overlay = this.props.overlay;
-
-    if(!name){
-      return;
-    }
-
-    space.deleteFile(space.filename)
-      .tap(() => this.handleSuccess(`'${name}' deleted successfully`))
-      .catch(this.handleError)
-      .finally(overlay.hide);
   },
   escapeDialog: function() {
     this.hideOverlay();
@@ -70,7 +57,7 @@ const FileOperations = React.createClass({
     const component = (
       <DeleteConfirmOverlay
         name={name}
-        onAccept={this.deleteFile}
+        onAccept={deleteFile}
         onCancel={this.hideOverlay} />
     );
 
@@ -92,12 +79,12 @@ const FileOperations = React.createClass({
     this.renderOverlay(component);
   },
   componentDidMount: function(){
-    this.keyCloseDialog = app.keypress(app.keypress.ESC, this.escapeDialog);
+    //this.keyCloseDialog = app.keypress(app.keypress.ESC, this.escapeDialog);
   },
   componentWillUnmount: function(){
-    if(this.keyCloseDialog) {
-     this.keyCloseDialog();
-    }
+    //if(this.keyCloseDialog) {
+     //this.keyCloseDialog();
+    //}
   },
   render: function(){
     return (

--- a/plugins/sidebar/file-operations.js
+++ b/plugins/sidebar/file-operations.js
@@ -9,7 +9,7 @@ const NewFileOverlay = require('./overlays/new-file');
 const DownloadOverlay = require('./overlays/download');
 const DeleteConfirmOverlay = require('./overlays/delete-confirm');
 const { reloadDevices } = require('../../src/actions/device.js');
-const { clearName, deleteFile, newFile, processSave } = require('../../src/actions/file');
+const { clearName, deleteFile, newFile, processSave, hideOverlay } = require('../../src/actions/file');
 
 const styles = require('./styles');
 
@@ -26,10 +26,6 @@ const FileOperations = React.createClass({
 
     toast.show(msg, { style: styles.successToast, timeout: 5000 });
   },
-  escapeDialog: function() {
-    this.hideOverlay();
-    clearName();
-  },
   renderOverlay: function(component){
     const overlay = this.props.overlay;
 
@@ -38,10 +34,6 @@ const FileOperations = React.createClass({
     }
 
     overlay.render(renderer, { backdrop: true });
-  },
-  hideOverlay: function(){
-    const overlay = this.props.overlay;
-    overlay.hide();
   },
   showDeleteOverlay: function(evt){
     evt.preventDefault();
@@ -58,7 +50,7 @@ const FileOperations = React.createClass({
       <DeleteConfirmOverlay
         name={name}
         onAccept={deleteFile}
-        onCancel={this.hideOverlay} />
+        onCancel={hideOverlay} />
     );
 
     this.renderOverlay(component);
@@ -70,21 +62,13 @@ const FileOperations = React.createClass({
 
     const component = (
       <DownloadOverlay
-        onCancel={this.hideOverlay}
+        onCancel={hideOverlay}
         irken={this.props.irken}
         handleSuccess={this.handleSuccess}
         handleError={this.handleError} />
     );
 
     this.renderOverlay(component);
-  },
-  componentDidMount: function(){
-    //this.keyCloseDialog = app.keypress(app.keypress.ESC, this.escapeDialog);
-  },
-  componentWillUnmount: function(){
-    //if(this.keyCloseDialog) {
-     //this.keyCloseDialog();
-    //}
   },
   render: function(){
     return (

--- a/plugins/sidebar/index.js
+++ b/plugins/sidebar/index.js
@@ -83,11 +83,6 @@ function sidebar(app, opts, done){
     React.render(Component, el, cb);
   });
 
-  const cwd = userConfig.get('cwd') || opts.defaultProject;
-  const lastFile = userConfig.get('last-file');
-
-  space.changeDir(cwd, () => loadFile(lastFile, done));
-
   // Internal Helpers
   function _checkUnsaved(file) {
     const unnamed = space.directory.every(function(x) {
@@ -116,8 +111,6 @@ function sidebar(app, opts, done){
   }
 
   function _renderOverlay(component){
-    //const overlay = this.props.overlay;
-
     function renderer(el){
       React.render(component, el);
     }
@@ -126,8 +119,6 @@ function sidebar(app, opts, done){
   }
 
   function _showCreateOverlay(){
-    //evt.preventDefault();
-
     const component = (
       <NewFileOverlay
         onAccept={processCreate}
@@ -155,6 +146,11 @@ function sidebar(app, opts, done){
 
   // Set up listeners
   fileStore.listen(_onChangeFileStore);
+
+  // Finish Loading Plugin
+  const cwd = userConfig.get('cwd') || opts.defaultProject;
+  const lastFile = userConfig.get('last-file');
+  space.changeDir(cwd, () => loadFile(lastFile, done));
 
 }
 

--- a/plugins/sidebar/index.js
+++ b/plugins/sidebar/index.js
@@ -15,7 +15,7 @@ const deviceStore = require('../../src/stores/device');
 const editorStore = require('../../src/stores/editor');
 const fileStore = require('../../src/stores/file');
 
-const { processCreate, processSave } = require('../../src/actions/file');
+const { processCreate, processSave, newFile } = require('../../src/actions/file');
 function noop(){}
 
 function sidebar(app, opts, done){
@@ -150,7 +150,14 @@ function sidebar(app, opts, done){
   // Finish Loading Plugin
   const cwd = userConfig.get('cwd') || opts.defaultProject;
   const lastFile = userConfig.get('last-file');
-  space.changeDir(cwd, () => loadFile(lastFile, done));
+  console.log(lastFile);
+  space.changeDir(cwd, () => loadFile(lastFile, (err) => {
+    if(err){
+      newFile();
+    }
+
+    done();
+  }));
 
 }
 

--- a/plugins/sidebar/overlays/new-file.js
+++ b/plugins/sidebar/overlays/new-file.js
@@ -33,7 +33,7 @@ class NewFileOverlay extends React.Component {
 
     return (
       <Card styles={styles.overlay}>
-        <h3 style={styles.overlayTitle}>Please name your file.</h3>
+        <h3 style={styles.overlayTitle}>Do you want to save the changes you made to New file?</h3>
         <TextField
           value={fileName}
           ref="filename"
@@ -42,8 +42,9 @@ class NewFileOverlay extends React.Component {
           floatingLabel
           onChange={this._onUpdateName} />
         <div style={styles.overlayButtonContainer}>
-          <Button onClick={this._onAccept}>Create</Button>
-          <Button onClick={this._onCancel}>Cancel</Button>
+          <Button onClick={this._onAccept}>Save As</Button>
+          <Button onClick={() => this._onCancel({ trash: true })}>Don't Save</Button>
+          <Button onClick={() => this._onCancel({ trash: false })}>Cancel</Button>
         </div>
       </Card>
     );
@@ -54,16 +55,16 @@ class NewFileOverlay extends React.Component {
 
     clearName();
     if(typeof onAccept === 'function'){
-      onAccept(fileName, evt);
+      onAccept(fileName);
     }
   }
 
-  _onCancel(evt){
+  _onCancel(status, evt){
     const { onCancel } = this.props;
 
     clearName();
     if(typeof onCancel === 'function'){
-      onCancel(evt);
+      onCancel(status);
     }
   }
 

--- a/src/actions/file.js
+++ b/src/actions/file.js
@@ -7,6 +7,14 @@ class FileActions {
     this.dispatch();
   }
 
+  deleteFile(name) {
+    this.dispatch(name);
+  }
+
+  hideOverlay() {
+    this.dispatch();
+  }
+
   newFile() {
     this.dispatch();
   }

--- a/src/actions/file.js
+++ b/src/actions/file.js
@@ -19,8 +19,16 @@ class FileActions {
     this.dispatch();
   }
 
+  loadFile(filename){
+    this.dispatch(filename);
+  }
+
   processCreate(name) {
     this.dispatch(name);
+  }
+
+  processNoCreate(status){
+    this.dispatch(status);
   }
 
   processSave() {

--- a/src/actions/file.js
+++ b/src/actions/file.js
@@ -7,9 +7,22 @@ class FileActions {
     this.dispatch();
   }
 
+  newFile() {
+    this.dispatch();
+  }
+
+  processCreate(name) {
+    this.dispatch(name);
+  }
+
+  processSave() {
+    this.dispatch();
+  }
+
   updateName(value) {
     this.dispatch(value);
   }
+
 }
 
 module.exports = alt.createActions(FileActions);

--- a/src/stores/file.js
+++ b/src/stores/file.js
@@ -1,19 +1,26 @@
 'use strict';
 
 const alt = require('../alt');
+const _ = require('lodash');
+const styles = require('../../plugins/sidebar/styles');
 
-const { clearName, updateName } = require('../actions/file');
+const { clearName, newFile, processCreate,
+  processSave, updateName } = require('../actions/file');
 
 class FileStore {
   constructor() {
 
     this.bindListeners({
       onClearName: clearName,
+      onNewFile: newFile,
+      onProcessCreate: processCreate,
+      onProcessSave: processSave,
       onUpdateName: updateName
     });
 
     this.state = {
-      fileName: ''
+      fileName: '',
+      showSaveOverlay: false
     };
 
   }
@@ -24,11 +31,109 @@ class FileStore {
     });
   }
 
+  onHideSave() {
+    this.setState({
+      showSaveOverlay: false
+    });
+  }
+
+  onProcessCreate(name) {
+    const { loadFile, overlay, workspace } = this.getInstance();
+
+    if(!name){
+      return;
+    }
+
+    workspace.filename.update(() => name);
+    //workspace.current.update(() => '');
+    // TODO: these should transparently accept cursors for all non-function params
+    workspace.saveFile(workspace.filename.deref(), workspace.current)
+      .tap(() => loadFile(name, () => this._handleSuccess(`'${name}' created successfully`)))
+      .catch(this._handleError)
+      .finally(overlay.hide);
+
+    this.onHideSave();
+  }
+
+  onProcessSave() {
+
+    const { workspace } = this.getInstance();
+
+    // TODO: reuse with checkUnsaved in sidebar index
+    const file = workspace.filename.deref();
+    const unnamed = workspace.directory.every(function(x) {
+      if(x.get('name') === file) {
+        return false;
+      }
+      else {
+        return true;
+      }
+    });
+    if(unnamed) {
+      this.setState({
+        fileName: file,
+        showSaveOverlay: true
+      });
+    }
+    else {
+      this.setState({ showSaveOverlay: false });
+      this._save();
+    }
+  }
+
+  _save() {
+    const { workspace } = this.getInstance();
+
+    const name = workspace.filename.deref();
+
+    // TODO: these should transparently accept cursors for all non-function params
+    workspace.saveFile(name, workspace.current)
+      .tap(() => this._handleSuccess(`'${name}' saved successfully`))
+      .catch(this._handleError);
+  }
+
+  onNewFile() {
+    const { workspace, userConfig } = this.getInstance();
+    workspace.current.update(() => '');
+
+    const directory = workspace.directory.deref();
+    const untitledNums = directory.filter(x => {
+      return x.get('name').match(/untitled/);
+    }).map(x => {
+      const untitled = x.get('name').match(/\d+/);
+      if (untitled) {
+        return parseInt(untitled[0]);
+      }
+    });
+
+    const untitledLast = untitledNums.max() || 0;
+    const builtName = `untitled${untitledLast + 1}`;
+
+    workspace.filename.update(() => builtName);
+
+    userConfig.set('last-file', builtName);
+  }
+
   onUpdateName(value) {
     this.setState({
       fileName: value
     });
   }
+
+  _handleError(err){
+    // leaving this in for better debugging of errors
+    console.log(err);
+    const { toast } = this.getInstance();
+
+    toast.show(err.message, { style: styles.errorToast });
+  }
+
+  _handleSuccess(msg){
+    const { toast } = this.getInstance();
+
+    toast.show(msg, { style: styles.successToast, timeout: 5000 });
+  }
+
 
 }
 

--- a/src/stores/file.js
+++ b/src/stores/file.js
@@ -45,7 +45,6 @@ class FileStore {
     }
 
     workspace.filename.update(() => name);
-    //workspace.current.update(() => '');
     // TODO: these should transparently accept cursors for all non-function params
     workspace.saveFile(workspace.filename.deref(), workspace.current)
       .tap(() => loadFile(name, () => this._handleSuccess(`'${name}' created successfully`)))
@@ -96,17 +95,19 @@ class FileStore {
     const { workspace, userConfig } = this.getInstance();
     workspace.current.update(() => '');
 
-    const directory = workspace.directory.deref();
-    const untitledNums = directory.filter(x => {
-      return x.get('name').match(/untitled/);
-    }).map(x => {
-      const untitled = x.get('name').match(/\d+/);
-      if (untitled) {
-        return parseInt(untitled[0]);
+    const directory = workspace.directory.toJS();
+    const untitledNums = _.reduce(directory, function(untitled, dirfile) {
+      if(dirfile.name.match(/untitled/)) {
+        const getnum = dirfile.name.match(/\d+/);
+        if (getnum) {
+          untitled.push(_.parseInt(getnum[0]));
+        }
       }
-    });
+      return untitled;
+    }, [0]);
 
-    const untitledLast = untitledNums.max() || 0;
+    const untitledLast = _.max(untitledNums);
+
     const builtName = `untitled${untitledLast + 1}`;
 
     workspace.filename.update(() => builtName);

--- a/src/stores/file.js
+++ b/src/stores/file.js
@@ -5,7 +5,7 @@ const _ = require('lodash');
 const alt = require('../alt');
 const styles = require('../../plugins/sidebar/styles');
 
-const { clearName, newFile, processCreate,
+const { clearName, deleteFile, hideOverlay, newFile, processCreate,
   processSave, updateName } = require('../actions/file');
 
 class FileStore {
@@ -13,6 +13,8 @@ class FileStore {
 
     this.bindListeners({
       onClearName: clearName,
+      onDeleteFile: deleteFile,
+      onHideOverlay: hideOverlay,
       onNewFile: newFile,
       onProcessCreate: processCreate,
       onProcessSave: processSave,
@@ -32,10 +34,33 @@ class FileStore {
     });
   }
 
+  onDeleteFile(name) {
+    const { overlay, workspace } = this.getInstance();
+
+    if(!name){
+      return;
+    }
+
+    workspace.deleteFile(workspace.filename)
+      .tap(() => this._handleSuccess(`'${name}' deleted successfully`))
+      .catch(this._handleError)
+      .finally(() => {
+        overlay.hide();
+        this.onNewFile();
+      });
+
+  }
+
   onHideSave() {
     this.setState({
       showSaveOverlay: false
     });
+  }
+
+  onHideOverlay() {
+    const { overlay } = this.getInstance();
+    overlay.hide();
+    this.onClearName();
   }
 
   onProcessCreate(name) {
@@ -112,6 +137,7 @@ class FileStore {
     const builtName = `untitled${untitledLast + 1}`;
 
     workspace.filename.update(() => builtName);
+    console.log('here, builtName', builtName);
 
     userConfig.set('last-file', builtName);
   }

--- a/src/stores/file.js
+++ b/src/stores/file.js
@@ -1,7 +1,8 @@
 'use strict';
 
-const alt = require('../alt');
 const _ = require('lodash');
+
+const alt = require('../alt');
 const styles = require('../../plugins/sidebar/styles');
 
 const { clearName, newFile, processCreate,

--- a/src/stores/file.js
+++ b/src/stores/file.js
@@ -119,7 +119,6 @@ class FileStore {
 
   onNewFile() {
     const { workspace, userConfig } = this.getInstance();
-    workspace.current.update(() => '');
 
     const directory = workspace.directory.toJS();
     const untitledNums = _.reduce(directory, function(untitled, dirfile) {
@@ -137,7 +136,7 @@ class FileStore {
     const builtName = `untitled${untitledLast + 1}`;
 
     workspace.filename.update(() => builtName);
-    console.log('here, builtName', builtName);
+    workspace.updateContent('');
 
     userConfig.set('last-file', builtName);
   }


### PR DESCRIPTION
#### What's this PR do?

Changes logic for new files and saving files. New files are now created as blank pages and named with untitled# (with # being the next number after the highest numbered untitled file in your working directory).

Unsaved files will Save As, prompting a Save As overlay with Untitled# showing in the filename field. 
Saved files will simply save to their current name.

Ctrl-S and the save button should work for both of these circumstances.
#### Where should the reviewer start?

npm install (to get Frylord updates)
npm run build
#### How should this be manually tested?

Open ChromeIDE, create a new file (with the New File button and with Ctrl-N). Write some text into the file. You shouldn't see any errors in the Dev Tools console. Save (using the Save button or Ctrl-S), should open the Save As overlay. Untitled# (#, based on file directory) should show in the filename input. Save the untitled file. Create and save a few more untitled files. Be sure the numbers are incrementing properly. Click the Save button or press Ctrl-S on a file that is already saved. It should simply save without prompting the Save As dialog.

Create a new file. Try to click away to a different file in your directory. ChromeIDE should ask you to Save As.

Try different scenarios with opening new files, saving, and navigating to be certain everything is working as expected.
#### What are the relevant tickets?

Closes #107 
