### PR TITLE
fix bug where last-file config option was undefined on reinstall causing crash - found by @urbantumbleweed

### DIFF
--- a/plugins/sidebar/index.js
+++ b/plugins/sidebar/index.js
@@ -110,7 +110,11 @@ function sidebar(app, opts, done){
   const lastFile = userConfig.get('last-file');
   console.log(lastFile);
   space.changeDir(cwd, () => {
-    loadFile(lastFile);
+    if(lastFile){
+      loadFile(lastFile);
+    } else {
+      newFile();
+    }
     done();
   });
 

--- a/src/stores/file.js
+++ b/src/stores/file.js
@@ -163,6 +163,10 @@ class FileStore {
   }
 
   onLoadFile(filename){
+    if(!filename){
+      return;
+    }
+
     const { workspace, userConfig } = this.getInstance();
     const { isNewFile } = this.state;
 


### PR DESCRIPTION
#### What's this PR do?

Fixes a bug where the `last-file` user config option could be undefined, causing the application to error out.
#### Where should the reviewer start?

Completely uninstall and reinstall the application.
#### How should this be manually tested?

Verify that the application can start up from scratch and the same file navigation behavior still applies as it normally does.
