### PR TITLE
adjustments for indent & dedent

### DIFF
--- a/plugins/editor/index.js
+++ b/plugins/editor/index.js
@@ -65,7 +65,8 @@ function editor(app, opts, done){
       codeEditor.setOption('extraKeys', {
         'Ctrl-Up': false,
         'Ctrl-Down': false,
-        Tab: false
+        'Tab': false,
+        'Shift-Tab': false
       });
       keyExtension.setup(app);
       editorStore.cm = codeEditor;

--- a/plugins/editor/key-extension.js
+++ b/plugins/editor/key-extension.js
@@ -2,7 +2,7 @@
 
 var { findNext, findPrevious } = require('../../src/actions/find');
 var { moveByScrollUpLine, moveByScrollDownLine } = require('../../src/actions/editor-move');
-var { indent } = require('../../src/actions/text-move');
+var { dedent, indent } = require('../../src/actions/text-move');
 var { print } = require('../../src/actions/system');
 var { hideOverlay, newFile, processSave } = require('../../src/actions/file');
 
@@ -43,6 +43,13 @@ const keyExtension = {
         exec: (evt) => {
           evt.preventDefault();
           indent();
+        }
+      },
+      shiftTab: {
+        code: 'SHIFT_TAB',
+        exec: (evt) => {
+          evt.preventDefault();
+          dedent();
         }
       },
       print: {

--- a/plugins/editor/pbasic.js
+++ b/plugins/editor/pbasic.js
@@ -1,26 +1,26 @@
 // CodeMirror, copyright (c) by Marijn Haverbeke and others
 // Distributed under an MIT license: http://codemirror.net/LICENSE
-"use strict";
+'use strict';
 
 module.exports = function(CodeMirror){
 
-  CodeMirror.defineMode("pbasic", function(conf, parserConf) {
+  CodeMirror.defineMode('pbasic', function(conf, parserConf) {
     var ERRORCLASS = 'error';
 
     function wordRegexp(words) {
-      return new RegExp("^((" + words.join(")|(") + "))\\b", "i");
+      return new RegExp('^((' + words.join(')|(') + '))\\b', 'i');
     }
 
     function getWordRange(word, start, end, base){
       var words = [];
 
       if (base) {
-        words.push(word)
-      };
+        words.push(word);
+      }
 
       for (var i = start; i < end + 1; i++) {
         words.push(word + i);
-      };
+      }
       return words;
     }
 
@@ -30,10 +30,6 @@ module.exports = function(CodeMirror){
     var doubleDelimiters = new RegExp("^((\\+=)|(\\-=)|(\\*=)|(%=)|(/=)|(&=)|(\\|=)|(\\^=))");
     var tripleDelimiters = new RegExp("^((//=)|(>>=)|(<<=)|(\\*\\*=))");
     var identifiers = new RegExp("^[_A-Za-z][_A-Za-z0-9]*");
-
-    var openingKeywords = ['select','#select','while','if','#if'];
-    var middleKeywords = ['else','#else','elseif','case', '#case'];
-    var endKeywords = ['next','loop','endselect','#endselect', 'endif', '#endif'];
 
     var etInstruction = ['DATA','FOR','NEXT','GOTO','GOSUB','RETURN','IF','BRANCH','LOOKUP','LOOKDOWN',
       'RANDOM','READ','WRITE','PAUSE','INPUT','OUTPUT','LOW','HIGH','TOGGLE','REVERSE','SEROUT','SERIN',
@@ -76,9 +72,6 @@ module.exports = function(CodeMirror){
 
     var stringPrefixes = '"';
 
-    var opening = wordRegexp(openingKeywords);
-    var middle = wordRegexp(middleKeywords);
-    var closing = wordRegexp(endKeywords);
     var etdirective = wordRegexp(etDirective);
     var ettargetmodule = wordRegexp(etTargetModule);
     var etioformatter = wordRegexp(etIOFormatter);
@@ -86,18 +79,7 @@ module.exports = function(CodeMirror){
     var etccdirective = wordRegexp(etCCDirective);
     var etconstant = wordRegexp(etConstant);
     var etinstruction = wordRegexp(etInstruction);
-    var doubleClosing = wordRegexp(['END']);
-    var doOpening = wordRegexp(['DO']);
 
-    var indentInfo = null;
-
-    function indent(_stream, state) {
-      state.currentIndent++;
-    }
-
-    function dedent(_stream, state) {
-      state.currentIndent--;
-    }
     // tokenizers
     function tokenBase(stream, state) {
       if (stream.eatSpace()) {
@@ -106,7 +88,7 @@ module.exports = function(CodeMirror){
 
       var ch = stream.peek();
 
-      // Handle Comments
+       //Handle Comments
       if (ch === "'") {
         stream.skipToEnd();
         return 'comment';
@@ -190,32 +172,6 @@ module.exports = function(CodeMirror){
       if (stream.match(etinstruction)) {
         return 'etInstruction';
       }
-      if (stream.match(doOpening)) {
-        indent(stream,state);
-        state.doInCurrentLine = true;
-        return 'keyword';
-      }
-      if (stream.match(opening)) {
-        if (! state.doInCurrentLine)
-          indent(stream,state);
-        else
-          state.doInCurrentLine = false;
-        return 'keyword';
-      }
-      if (stream.match(middle)) {
-        return 'keyword';
-      }
-
-      if (stream.match(doubleClosing)) {
-        dedent(stream,state);
-        dedent(stream,state);
-        return 'keyword';
-      }
-      if (stream.match(closing)) {
-        dedent(stream,state);
-        return 'keyword';
-      }
-
       if (stream.match(identifiers)) {
         return 'variable';
       }
@@ -228,7 +184,7 @@ module.exports = function(CodeMirror){
     }
 
     function tokenStringFactory(delimiter) {
-      var singleline = delimiter.length == 1;
+      var singleline = delimiter.length === 1;
       var OUTCLASS = 'string';
 
       return function(stream, state) {
@@ -268,62 +224,29 @@ module.exports = function(CodeMirror){
       }
 
 
-      var delimiter_index = '[({'.indexOf(current);
-      if (delimiter_index !== -1) {
-        indent(stream, state );
-      }
-      if (indentInfo === 'dedent') {
-        if (dedent(stream, state)) {
-          return ERRORCLASS;
-        }
-      }
-      delimiter_index = '])}'.indexOf(current);
-      if (delimiter_index !== -1) {
-        if (dedent(stream, state)) {
-          return ERRORCLASS;
-        }
-      }
-
       return style;
     }
 
     var external = {
-      electricChars:"dDpPtTfFeE ",
       startState: function() {
         return {
           tokenize: tokenBase,
-          lastToken: null,
-          currentIndent: 0,
-          nextLineIndent: 0,
-          doInCurrentLine: false
+          lastToken: null
         };
       },
 
       token: function(stream, state) {
-        if (stream.sol()) {
-          state.currentIndent += state.nextLineIndent;
-          state.nextLineIndent = 0;
-          state.doInCurrentLine = 0;
-        }
         var style = tokenLexer(stream, state);
 
-        state.lastToken = {style:style, content: stream.current()};
+        state.lastToken = {style: style, content: stream.current()};
 
         return style;
-      },
-
-      indent: function(state, textAfter) {
-        var trueText = textAfter.replace(/^\s+|\s+$/g, '') ;
-        if (trueText.match(closing) || trueText.match(doubleClosing) || trueText.match(middle)) return conf.indentUnit*(state.currentIndent-1);
-        if(state.currentIndent < 0) return 0;
-        return state.currentIndent * conf.indentUnit;
       }
-
     };
     return external;
   });
 
-  CodeMirror.defineMIME("text/pbasic", "pbasic");
+  CodeMirror.defineMIME('text/pbasic', 'pbasic');
 
-}
+};
 

--- a/src/actions/text-move.js
+++ b/src/actions/text-move.js
@@ -7,6 +7,9 @@ class TextMoveActions {
   indent() {
     this.dispatch();
   }
+  dedent() {
+    this.dispatch();
+  }
 
 }
 

--- a/src/stores/editor.js
+++ b/src/stores/editor.js
@@ -5,7 +5,7 @@ const alt = require('../alt');
 const { findNext, findPrevious } = require('../actions/find');
 const { handleInput } = require('../actions/editor');
 const { moveByScrollUpLine, moveByScrollDownLine } = require('../actions/editor-move');
-const { indent } = require('../actions/text-move');
+const { dedent, indent } = require('../actions/text-move');
 const { print } = require('../actions/system');
 
 class EditorStore {
@@ -17,6 +17,7 @@ class EditorStore {
       onHandleInput: handleInput,
       onMoveByScrollUpLine: moveByScrollUpLine,
       onMoveByScrollDownLine: moveByScrollDownLine,
+      onDedent: dedent,
       onIndent: indent,
       onPrint: print
     });
@@ -53,7 +54,12 @@ class EditorStore {
   onIndent() {
     const { cm } = this.getInstance();
 
-    cm.execCommand('insertSoftTab');
+    cm.execCommand('indentMore');
+  }
+  onDedent() {
+    const { cm } = this.getInstance();
+
+    cm.execCommand('indentLess');
   }
   onPrint() {
     window.print();


### PR DESCRIPTION
#### What's this PR do?

Sets up the TAB key press to do a two space indent while also working with block selections.
Sets up SHIFT-TAB key press to do a two space dedent while also working with block selections.
#### Where should the reviewer start?

pull this branch
npm run build
#### How should this be manually tested?

Initially try to TAB and SHIFT-TAB a single line. Notice the indent and dedent behavior. Select a block of text. Be sure both indent and dedent are working for that.

Play around with text in the editor. This PR will impact much of the behavior around spacing and indents/dedents in code blocks. Some auto-formatting that was happening before may not happen any more.  Ensure all syntax highlighting is still working as expected. See the background context below.
#### Any background context you want to provide?

The indent/dedent behaviors stem from two different locations in ParallaxIDE. The first is the behavior of what action the TAB/SHIFT-TAB key takes. This was changed to a action that better suits our needs. 

The second is auto-formatting being done around paragraphs by our defined CodeMirror Mode (such as automatically indent on the line after a **DO** or an **IF**). The auto-formatting was not set up for PBASIC, so I needed to remove it to get indent/dedent working properly. If we want auto-formatting back, we will need to bring it back specifically for PBASIC.
#### What are the relevant tickets?

Closes #120 
Closes #121 
