### PR TITLE
add saveAs action with keypress

### DIFF
--- a/plugins/editor/key-extension.js
+++ b/plugins/editor/key-extension.js
@@ -4,7 +4,7 @@ var { findNext, findPrevious } = require('../../src/actions/find');
 var { moveByScrollUpLine, moveByScrollDownLine } = require('../../src/actions/editor-move');
 var { indent } = require('../../src/actions/text-move');
 var { print } = require('../../src/actions/system');
-var { hideOverlay, newFile, processSave } = require('../../src/actions/file');
+var { hideOverlay, newFile, processSave, processSaveAs } = require('../../src/actions/file');
 
 const keyExtension = {
   setup: function(app) {
@@ -66,6 +66,13 @@ const keyExtension = {
           processSave();
         }
       },
+      saveAs: {
+        code: 'CTRL_SHIFT_S',
+        exec: (evt) => {
+          evt.preventDefault();
+          processSaveAs();
+        }
+      },
       hideOverlay: {
         code: 'ESC',
         exec: (evt) => {
@@ -77,14 +84,21 @@ const keyExtension = {
 
     const customPredicates = {
       CTRL_N: function({ ctrlKey, metaKey, keyCode }){
-          return ((ctrlKey === true || metaKey === true) && keyCode === 78);
-        }
+        return ((ctrlKey === true || metaKey === true) && keyCode === 78);
+      },
+      CTRL_SHIFT_S: function({ ctrlKey, metaKey, keyCode, shiftKey }){
+        return ((ctrlKey === true || metaKey === true) && shiftKey === true && keyCode === 83);
+      },
+      CTRL_S: function({ ctrlKey, metaKey, keyCode, shiftKey }){
+        return ((ctrlKey === true || metaKey === true) && shiftKey === false && keyCode === 83);
+      }
+
     };
 
     function setCodeMirrorCommands() {
       for (let cmd in cmCommands) {
         const code = cmCommands[cmd].code;
-        const predicate = app.keypress[code] || customPredicates[code];
+        const predicate = customPredicates[code] || app.keypress[code];
         cmCommands[cmd].removeCode = app.keypress(predicate, cmCommands[cmd].exec);
       }
     }

--- a/src/actions/file.js
+++ b/src/actions/file.js
@@ -35,6 +35,10 @@ class FileActions {
     this.dispatch();
   }
 
+  processSaveAs() {
+    this.dispatch();
+  }
+
   updateName(value) {
     this.dispatch(value);
   }

--- a/src/stores/file.js
+++ b/src/stores/file.js
@@ -5,8 +5,9 @@ const _ = require('lodash');
 const alt = require('../alt');
 const styles = require('../../plugins/sidebar/styles');
 
-const { clearName, deleteFile, hideOverlay, newFile, processCreate,
-  processNoCreate, processSave, updateName, loadFile } = require('../actions/file');
+const { clearName, deleteFile, hideOverlay, loadFile, newFile,
+  processCreate, processNoCreate, processSave, processSaveAs,
+  updateName } = require('../actions/file');
 
 class FileStore {
   constructor() {
@@ -17,9 +18,10 @@ class FileStore {
       onHideOverlay: hideOverlay,
       onNewFile: newFile,
       onLoadFile: loadFile,
-      onProcessNoCreate: processNoCreate,
       onProcessCreate: processCreate,
+      onProcessNoCreate: processNoCreate,
       onProcessSave: processSave,
+      onProcessSaveAs: processSaveAs,
       onUpdateName: updateName
     });
 
@@ -116,6 +118,10 @@ class FileStore {
       this.setState({ showSaveOverlay: false });
       this._save();
     }
+  }
+
+  onProcessSaveAs() {
+    this.setState({ showSaveOverlay: true });
   }
 
   _save() {


### PR DESCRIPTION
#### What's this PR do?

Adds the ability to Save As from any file using the keypress CTRL-SHIFT-S.
#### Where should the reviewer start?

Load the branch.
npm run build
#### How should this be manually tested?

Open a file with some text inside. Ensure you can save with CTRL-S or by clicking the Save button.

Next try to Save As with CTRL-SHIFT-S. You should get a dialog where you can enter a new filename, then press Save As in the dialog. The file should save and navigate you to the new file. 
#### What are the relevant tickets?

Closes #152 
Closes #155 
