### PR TITLE
Print code

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,8 +8,6 @@
 
     <style type="text/css">
       html, body {
-        width: 100%;
-        height: 100%;
         margin: 0;
         padding: 0;
         font-family: Roboto, 'Helvetica Neue', Helvetica, Arial;
@@ -19,45 +17,58 @@
         text-rendering: optimizeLegibility;
       }
 
-      .CodeMirror {
-        display: flex;
-        flex-direction: column;
-        flex: 1;
-      }
+      @media not print {
+        html, body {
+          width: 100%;
+          height: 100%;
+        }
 
-      .CodeMirror-scroll {
-        flex: 1;
-      }
+        .CodeMirror {
+          display: flex;
+          flex-direction: column;
+          flex: 1;
+        }
 
-      .mfb-component__child-icon.ion-code-download {
-        font-size: 22px;
-      }
+        .CodeMirror-scroll {
+          flex: 1;
+        }
 
-      .Select {
-        flex: 1;
+        .mfb-component__child-icon.ion-code-download {
+          font-size: 22px;
+        }
       }
 
       @media print {
+        html {
+          height: auto;
+        }
+
         body * {
           visibility: hidden;
         }
 
-        #editorContainer, #editorContainer * {
+        #editorContainer,
+        #editorContainer * {
           visibility: visible;
         }
 
         #editorContainer {
-          background-color: white;
-          width: 100%;
-          height: 100%;
-          position: fixed;
-          left: 0;
+          display: block !important;
+          position: absolute;
           top: 0;
-          margin: 0;
-          padding: 15px;
-          overflow: visible !important;
-          float: none !important;
+          left: 0;
+        }
 
+        #editorContainer .CodeMirror {
+          height: auto;
+        }
+
+        #editorContainer .CodeMirror-cursors {
+          visibility: visible;
+        }
+
+        #editorContainer .CodeMirror-cursor {
+          background: transparent;
         }
       }
 

--- a/index.html
+++ b/index.html
@@ -38,10 +38,29 @@
       }
 
       @media print {
-        .Sidebar-main {
-          display: none;
+        body * {
+          visibility: hidden;
+        }
+
+        #editorContainer, #editorContainer * {
+          visibility: visible;
+        }
+
+        #editorContainer {
+          background-color: white;
+          width: 100%;
+          height: 100%;
+          position: fixed;
+          left: 0;
+          top: 0;
+          margin: 0;
+          padding: 15px;
+          overflow: visible !important;
+          float: none !important;
+
         }
       }
+
     </style>
   </head>
   <body>

--- a/src/stores/editor.js
+++ b/src/stores/editor.js
@@ -56,7 +56,14 @@ class EditorStore {
     cm.execCommand('insertSoftTab');
   }
   onPrint() {
+    const { cm, workspace } = this.getInstance();
+
+    const { title } = document;
+    document.title = workspace.filename.deref();
+    cm.setOption('viewportMargin', Infinity);
     window.print();
+    document.title = title;
+    cm.setOption('viewportMargin', 10);
   }
 
 }


### PR DESCRIPTION
#### What's this PR do?

Allows you to print the text in the code editor with none of the "chrome" around the outside.
#### Where should the reviewer start?

Fetch and rebuild app.
#### How should this be manually tested?

Create a really long file and try to print it.  You should see that all the text is printed (multiple pages).  You can also try to "Print to PDF" in chrome which will use the file's name in the editor as the filename when trying to save.
#### Any background context you want to provide?

This was quite a pain to implement.  If there are any problems, it might be better to create a new window with **just** CodeMirror mounted and print that, instead of hiding the rest of the application with CSS.  The trick to get the print title to match the filename required setting the `document.title` to the name and then swapping it back to `Parallax IDE` after the print, which was pretty neat.
#### What are the relevant tickets?

Closes #127 
#### Screenshots (if appropriate)

![screen shot 2015-07-01 at 6 50 25 pm](https://cloud.githubusercontent.com/assets/992373/8468501/1525a6dc-2022-11e5-897d-279ab87c6b3b.png)
