### PR TITLE
Transmit pane

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "alt": "^0.16.7",
-    "bs2-serial": "^0.9.0",
+    "bs2-serial": "^0.10.0",
     "codemirror": "^4.13.0",
     "frylord": "^0.6.0",
     "holovisor": "^0.2.0",

--- a/plugins/editor/index.js
+++ b/plugins/editor/index.js
@@ -24,6 +24,7 @@ const { handleInput } = require('../../src/actions/editor');
 const DocumentsStore = require('../../src/stores/documents');
 
 const TransmissionBar = require('./transmission-bar');
+const TransmitPane = require('./transmit-pane');
 
 const makeToasts = require('../../src/lib/toasts');
 
@@ -32,6 +33,7 @@ function editor(app, opts, done){
   var codeEditor;
   var outputConsole;
   var transmission;
+  var transmitPane;
 
   function refreshConsole(){
     const { text } = consoleStore.getState();
@@ -109,6 +111,12 @@ function editor(app, opts, done){
       fileStore.documents = new DocumentsStore(codeEditor);
     }
 
+
+    if(!transmitPane) {
+      transmitPane = document.createElement('div');
+      el.appendChild(transmitPane);
+      React.render(<TransmitPane />, transmitPane);
+    }
     if(!outputConsole){
       outputConsole = document.createElement('pre');
       outputConsole.style.height = '200px';

--- a/plugins/editor/styles.js
+++ b/plugins/editor/styles.js
@@ -35,6 +35,22 @@ const styles = {
   },
   tx: {
     backgroundColor: red
+  },
+  transmit: {
+    margin: 0,
+    height: '32px',
+    backgroundColor: 'rgba(255,203,0,.1)'
+  },
+  transmitInput: {
+    border: '0px',
+    backgroundColor: 'transparent',
+    outline: 'none',
+    resize: 'none',
+    width: '100%',
+    padding: '5px 10px',
+    fontSize: 'inherit',
+    fontFamily: 'inherit',
+    boxSizing: 'border-box'
   }
 };
 

--- a/plugins/editor/styles.js
+++ b/plugins/editor/styles.js
@@ -39,7 +39,8 @@ const styles = {
   transmit: {
     margin: 0,
     height: '32px',
-    backgroundColor: 'rgba(255,203,0,.1)'
+    backgroundColor: 'white',
+    boxShadow: 'inset 0px 5px 10px -5px rgba(0, 0, 0, 0.26)'
   },
   transmitInput: {
     border: '0px',

--- a/plugins/editor/transmit-pane.js
+++ b/plugins/editor/transmit-pane.js
@@ -16,9 +16,18 @@ class TransmitPane extends React.Component {
     }
   }
 
-  handleChange(event) {
-    const { value } = event.target;
-    transmitInput(value);
+  handleKeyPress(event) {
+    const { keyCode } = event.nativeEvent;
+    if ((keyCode >= 32 && keyCode <= 127) ||
+        (keyCode >= 160 && keyCode <= 255)) {
+      transmitInput(keyCode);
+    }
+  }
+
+  handlePaste(event) {
+    const { clipboardData } = event;
+    const data = clipboardData.getData('text/plain');
+    transmitInput(data);
   }
 
   render() {
@@ -30,7 +39,8 @@ class TransmitPane extends React.Component {
           name='transmitInput'
           value={text}
           onKeyDown={this.handleKeyDown}
-          onChange={this.handleChange}
+          onKeyPress={this.handleKeyPress}
+          onPaste={this.handlePaste}
           rows='1'
           disabled={!connected} />
         <br />

--- a/plugins/editor/transmit-pane.js
+++ b/plugins/editor/transmit-pane.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const React = require('react');
+const { createContainer } = require('sovereign');
+
+const styles = require('./styles');
+const transmissionStore = require('../../src/stores/transmission');
+const { transmitInput } = require('../../src/actions/transmission');
+
+class TransmitPane extends React.Component {
+
+  handleInput(event) {
+    transmitInput(event.key);
+  }
+
+  render() {
+    return (
+      <div style={styles.transmit}>
+        <textarea style={styles.transmitInput} name='transmitInput'
+          onKeyPress={this.handleInput} rows='1' />
+        <br />
+      </div>
+    );
+  }
+}
+
+module.exports = createContainer(TransmitPane, {
+  getStores(){
+    return {
+      deviceStore: transmissionStore
+    };
+  },
+
+  getPropsFromStores() {
+    return transmissionStore.getState();
+  }
+});

--- a/plugins/editor/transmit-pane.js
+++ b/plugins/editor/transmit-pane.js
@@ -12,24 +12,29 @@ class TransmitPane extends React.Component {
   handleKeyDown(event) {
     const { keyCode } = event.nativeEvent;
     if (keyCode < 32 || (keyCode > 127 && keyCode < 160)) {
-      transmitInput(event);
+      transmitInput(keyCode);
     }
   }
   handleKeyPress(event) {
     const { keyCode } = event.nativeEvent;
     if ((keyCode >= 32 && keyCode <= 127) ||
         (keyCode >= 160 && keyCode <= 255)) {
-      transmitInput(event);
+      transmitInput(keyCode);
     }
   }
 
   render() {
-    const { connected, transmitText } = this.props;
+    const { connected, text } = this.props;
     return (
       <div style={styles.transmit}>
-        <textarea style={styles.transmitInput} name='transmitInput'
-          value={ transmitText } onKeyDown={this.handleKeyDown}
-          onKeyPress={this.handleKeyPress} rows='1' disabled={!connected} />
+        <textarea
+          style={styles.transmitInput}
+          name='transmitInput'
+          value={text}
+          onKeyDown={this.handleKeyDown}
+          onKeyPress={this.handleKeyPress}
+          rows='1'
+          disabled={!connected} />
         <br />
       </div>
     );

--- a/plugins/editor/transmit-pane.js
+++ b/plugins/editor/transmit-pane.js
@@ -4,20 +4,33 @@ const React = require('react');
 const { createContainer } = require('sovereign');
 
 const styles = require('./styles');
-const transmissionStore = require('../../src/stores/transmission');
-const { transmitInput } = require('../../src/actions/transmission');
+const deviceStore = require('../../src/stores/device');
+const { transmitInput } = require('../../src/actions/device');
 
 class TransmitPane extends React.Component {
 
-  handleInput(event) {
-    transmitInput(event.key);
+
+  handleKeyDown(event) {
+    const { keyCode } = event.nativeEvent;
+    if (keyCode < 32 || (keyCode > 127 && keyCode < 160)) {
+      transmitInput(event);
+    }
+  }
+  handleKeyPress(event) {
+    const { keyCode } = event.nativeEvent;
+    if ((keyCode >= 32 && keyCode <= 127) ||
+        (keyCode >= 160 && keyCode <= 255)) {
+      transmitInput(event);
+    }
   }
 
   render() {
+    const { connection, transmitText } = this.props;
     return (
       <div style={styles.transmit}>
         <textarea style={styles.transmitInput} name='transmitInput'
-          onKeyPress={this.handleInput} rows='1' />
+          value={ transmitText } onKeyDown={this.handleKeyDown}
+          onKeyPress={this.handleKeyPress} rows='1' disabled={!connection} />
         <br />
       </div>
     );
@@ -27,11 +40,11 @@ class TransmitPane extends React.Component {
 module.exports = createContainer(TransmitPane, {
   getStores(){
     return {
-      deviceStore: transmissionStore
+      deviceStore: deviceStore
     };
   },
 
   getPropsFromStores() {
-    return transmissionStore.getState();
+    return deviceStore.getState();
   }
 });

--- a/plugins/editor/transmit-pane.js
+++ b/plugins/editor/transmit-pane.js
@@ -12,24 +12,27 @@ class TransmitPane extends React.Component {
   handleKeyDown(event) {
     const { keyCode } = event.nativeEvent;
     if (keyCode < 32 || (keyCode > 127 && keyCode < 160)) {
-      transmitInput(event);
+      transmitInput(keyCode);
     }
   }
-  handleKeyPress(event) {
-    const { keyCode } = event.nativeEvent;
-    if ((keyCode >= 32 && keyCode <= 127) ||
-        (keyCode >= 160 && keyCode <= 255)) {
-      transmitInput(event);
-    }
+
+  handleChange(event) {
+    const { value } = event.target;
+    transmitInput(value);
   }
 
   render() {
     const { connected, transmitText } = this.props;
     return (
       <div style={styles.transmit}>
-        <textarea style={styles.transmitInput} name='transmitInput'
-          value={ transmitText } onKeyDown={this.handleKeyDown}
-          onKeyPress={this.handleKeyPress} rows='1' disabled={!connected} />
+        <textarea style={styles.transmitInput}
+          name='transmitInput'
+          value={ transmitText }
+          onKeyDown={this.handleKeyDown}
+          onChange={this.handleChange}
+          rows='1'
+          disabled={!connected}
+        />
         <br />
       </div>
     );

--- a/plugins/editor/transmit-pane.js
+++ b/plugins/editor/transmit-pane.js
@@ -7,10 +7,17 @@ const styles = require('./styles');
 const transmissionStore = require('../../src/stores/transmission');
 const { transmitInput } = require('../../src/actions/transmission');
 
+const ignore = [16, 17, 18, 20];
+
 class TransmitPane extends React.Component {
 
   handleKeyDown(event) {
     const { keyCode } = event.nativeEvent;
+
+    if (ignore.indexOf(keyCode) > -1) {
+      return;
+    }
+
     if (keyCode < 32 || (keyCode > 127 && keyCode < 160)) {
       transmitInput(keyCode);
     }
@@ -18,6 +25,7 @@ class TransmitPane extends React.Component {
 
   handleKeyPress(event) {
     const { keyCode } = event.nativeEvent;
+
     if ((keyCode >= 32 && keyCode <= 127) ||
         (keyCode >= 160 && keyCode <= 255)) {
       transmitInput(keyCode);

--- a/plugins/editor/transmit-pane.js
+++ b/plugins/editor/transmit-pane.js
@@ -4,11 +4,10 @@ const React = require('react');
 const { createContainer } = require('sovereign');
 
 const styles = require('./styles');
-const deviceStore = require('../../src/stores/device');
-const { transmitInput } = require('../../src/actions/device');
+const transmissionStore = require('../../src/stores/transmission');
+const { transmitInput } = require('../../src/actions/transmission');
 
 class TransmitPane extends React.Component {
-
 
   handleKeyDown(event) {
     const { keyCode } = event.nativeEvent;
@@ -25,12 +24,12 @@ class TransmitPane extends React.Component {
   }
 
   render() {
-    const { connection, transmitText } = this.props;
+    const { connected, transmitText } = this.props;
     return (
       <div style={styles.transmit}>
         <textarea style={styles.transmitInput} name='transmitInput'
           value={ transmitText } onKeyDown={this.handleKeyDown}
-          onKeyPress={this.handleKeyPress} rows='1' disabled={!connection} />
+          onKeyPress={this.handleKeyPress} rows='1' disabled={!connected} />
         <br />
       </div>
     );
@@ -40,11 +39,11 @@ class TransmitPane extends React.Component {
 module.exports = createContainer(TransmitPane, {
   getStores(){
     return {
-      deviceStore: deviceStore
+      transmissionStore: transmissionStore
     };
   },
 
   getPropsFromStores() {
-    return deviceStore.getState();
+    return transmissionStore.getState();
   }
 });

--- a/plugins/sidebar/index.js
+++ b/plugins/sidebar/index.js
@@ -11,6 +11,7 @@ const ProjectOperations = require('./project-operations');
 
 const deviceStore = require('../../src/stores/device');
 const fileStore = require('../../src/stores/file');
+const transmissionStore = require('../../src/stores/transmission');
 
 const { loadFile } = require('../../src/actions/file');
 
@@ -59,6 +60,8 @@ function sidebar(app, opts, done){
 
   fileStore.workspace = space;
   fileStore.userConfig = userConfig;
+
+  transmissionStore.getBoard = getBoard;
 
   done();
 }

--- a/src/actions/device.js
+++ b/src/actions/device.js
@@ -16,10 +16,6 @@ class DeviceActions {
     this.dispatch();
   }
 
-  transmitInput(input) {
-    this.dispatch(input);
-  }
-
   updateSelected(device) {
     this.dispatch(device);
   }

--- a/src/actions/device.js
+++ b/src/actions/device.js
@@ -16,6 +16,10 @@ class DeviceActions {
     this.dispatch();
   }
 
+  transmitInput(input) {
+    this.dispatch(input);
+  }
+
   updateSelected(device) {
     this.dispatch(device);
   }

--- a/src/actions/transmission.js
+++ b/src/actions/transmission.js
@@ -23,10 +23,6 @@ class TransmissionActions {
   transmitInput(input) {
     this.dispatch(input);
   }
-
-  transmitParsed(input) {
-    this.dispatch(input);
-  }
 }
 
 module.exports = alt.createActions(TransmissionActions);

--- a/src/actions/transmission.js
+++ b/src/actions/transmission.js
@@ -11,9 +11,6 @@ class TransmissionActions {
     this.dispatch();
   }
 
-  transmitInput(input) {
-    this.dispatch(input);
-  }
 }
 
 module.exports = alt.createActions(TransmissionActions);

--- a/src/actions/transmission.js
+++ b/src/actions/transmission.js
@@ -10,7 +10,6 @@ class TransmissionActions {
   tx() {
     this.dispatch();
   }
-
 }
 
 module.exports = alt.createActions(TransmissionActions);

--- a/src/actions/transmission.js
+++ b/src/actions/transmission.js
@@ -10,6 +10,10 @@ class TransmissionActions {
   tx() {
     this.dispatch();
   }
+
+  transmitInput(input) {
+    this.dispatch(input);
+  }
 }
 
 module.exports = alt.createActions(TransmissionActions);

--- a/src/actions/transmission.js
+++ b/src/actions/transmission.js
@@ -3,12 +3,25 @@
 const alt = require('../alt');
 
 class TransmissionActions {
+
+  connected() {
+    this.dispatch();
+  }
+
+  disconnected() {
+    this.dispatch();
+  }
+
   rx() {
     this.dispatch();
   }
 
   tx() {
     this.dispatch();
+  }
+
+  transmitInput(input) {
+    this.dispatch(input);
   }
 }
 

--- a/src/actions/transmission.js
+++ b/src/actions/transmission.js
@@ -23,6 +23,10 @@ class TransmissionActions {
   transmitInput(input) {
     this.dispatch(input);
   }
+
+  transmitParsed(input) {
+    this.dispatch(input);
+  }
 }
 
 module.exports = alt.createActions(TransmissionActions);

--- a/src/stores/console.js
+++ b/src/stores/console.js
@@ -106,6 +106,7 @@ class ConsoleStore {
       } else {
         lines[pointerLine] = targetLine.slice(0, pointerColumn - 1);
       }
+      this.setState({ pointerColumn: pointerColumn - 1 });
     } else {
       const prevLineNum = Math.max(0, pointerLine - 1);
       const prevLine = lines[prevLineNum] || '';

--- a/src/stores/device.js
+++ b/src/stores/device.js
@@ -7,7 +7,7 @@ const alt = require('../alt');
 const { rx, tx } = require('../actions/transmission');
 const { hideDownload, showDownload } = require('../actions/overlay');
 const { clearOutput, output } = require('../actions/console');
-const { enableAuto, disableAuto, reloadDevices, updateSelected } = require('../actions/device');
+const { enableAuto, disableAuto, reloadDevices, transmitInput, updateSelected } = require('../actions/device');
 
 class DeviceStore {
   constructor() {
@@ -16,17 +16,20 @@ class DeviceStore {
       onReloadDevices: [reloadDevices, showDownload],
       onDisableAuto: disableAuto,
       onEnableAuto: enableAuto,
+      onTransmitInput: transmitInput,
       onUpdateSelected: updateSelected
     });
 
     this.state = {
       auto: true,
+      connection: null,
       devices: [],
       devicePath: null,
       message: null,
+      progress: 0,
       searching: true,
       selectedDevice: null,
-      progress: 0
+      transmitText: 'hi'
     };
 
     this.messages = {
@@ -72,6 +75,20 @@ class DeviceStore {
           this._checkDevices();
         }
     });
+  }
+
+  onTransmitInput(input) {
+
+    const { keyCode } = input.nativeEvent;
+    this._updateTransmitText(keyCode);
+
+    const { selectedDevice } = this.state;
+    const { getBoard } = this.getInstance();
+
+    const board = getBoard(selectedDevice);
+
+    board.write(keyCode)
+      .catch((err) => this._handleError(err));
   }
 
   onUpdateSelected(device) {
@@ -156,6 +173,7 @@ class DeviceStore {
       .then(() => board.on('terminal', output))
       .then(() => board.on('terminal', rx))
       .tap(() => this._handleClear())
+      .tap(() => this._watchConnection(board))
       .tap(() => this._handleSuccess(`'${name}' downloaded successfully`))
       .catch((err) => this._handleError(err))
       .finally(() => {
@@ -163,6 +181,46 @@ class DeviceStore {
         this.setState({ progress: 0 });
         hideDownload();
       });
+  }
+
+  _updateTransmitText(keyCode) {
+
+    const key = String.fromCharCode(keyCode);
+    const { transmitText } = this.state;
+
+    let updatedTransmitText = null;
+    const ignorePress = [16, 17, 18, 20];
+
+    if ((keyCode >= 32 && keyCode <= 127) ||
+        (keyCode >= 160 && keyCode <= 255)) {
+      updatedTransmitText = transmitText + key;
+    } else if (keyCode === 8) {
+      updatedTransmitText = transmitText.slice(0, -1);
+    } else if (keyCode === 10 || keyCode === 13) {
+      updatedTransmitText = transmitText + '\n';
+    } else if (ignorePress.indexOf(keyCode) > -1) {
+      return;
+    } else {
+      updatedTransmitText = transmitText + ' ';
+    }
+
+    this.setState({ transmitText: updatedTransmitText });
+
+  }
+
+  _watchConnection(board) {
+
+    const connection = setInterval(() => {
+      if(!board.isOpen()) {
+        clearInterval(connection);
+        this.setState({ connection: null });
+      }
+    }, 1000);
+
+    this.setState({
+      connection: connection,
+      transmitText: ''
+    });
   }
 
   _handleClear(){

--- a/src/stores/device.js
+++ b/src/stores/device.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 
 const alt = require('../alt');
 
-const { connected, disconnected, rx, tx, transmitParsed } = require('../actions/transmission');
+const { connected, disconnected, rx, tx } = require('../actions/transmission');
 const { hideDownload, showDownload } = require('../actions/overlay');
 const { clearOutput, output } = require('../actions/console');
 const { enableAuto, disableAuto, reloadDevices, updateSelected } = require('../actions/device');
@@ -156,7 +156,6 @@ class DeviceStore {
       .tap(() => clearOutput())
       .then(() => board.on('terminal', output))
       .then(() => board.on('terminal', rx))
-      .then(() => board.on('transmit', transmitParsed))
       .then(() => board.on('close', disconnected))
       .tap(() => this._handleClear())
       .tap(() => this._handleSuccess(`'${name}' downloaded successfully`))

--- a/src/stores/device.js
+++ b/src/stores/device.js
@@ -80,6 +80,8 @@ class DeviceStore {
   onTransmitInput(input) {
 
     const { keyCode } = input.nativeEvent;
+    const keyCodeArr = new Uint8Array([keyCode]);
+
     this._updateTransmitText(keyCode);
 
     const { selectedDevice } = this.state;
@@ -87,7 +89,7 @@ class DeviceStore {
 
     const board = getBoard(selectedDevice);
 
-    board.write(keyCode)
+    board.write(keyCodeArr.buffer)
       .catch((err) => this._handleError(err));
   }
 

--- a/src/stores/device.js
+++ b/src/stores/device.js
@@ -29,7 +29,7 @@ class DeviceStore {
       progress: 0,
       searching: true,
       selectedDevice: null,
-      transmitText: 'hi'
+      transmitText: ''
     };
 
     this.messages = {

--- a/src/stores/device.js
+++ b/src/stores/device.js
@@ -134,6 +134,7 @@ class DeviceStore {
       this.setState({ progress: progress });
     }
 
+
     const { workspace, getBoard } = this.getInstance();
     const { selectedDevice } = this.state;
 

--- a/src/stores/device.js
+++ b/src/stores/device.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 
 const alt = require('../alt');
 
-const { connected, disconnected, rx, tx } = require('../actions/transmission');
+const { connected, disconnected, rx, tx, transmitParsed } = require('../actions/transmission');
 const { hideDownload, showDownload } = require('../actions/overlay');
 const { clearOutput, output } = require('../actions/console');
 const { enableAuto, disableAuto, reloadDevices, updateSelected } = require('../actions/device');
@@ -156,9 +156,9 @@ class DeviceStore {
       .tap(() => clearOutput())
       .then(() => board.on('terminal', output))
       .then(() => board.on('terminal', rx))
+      .then(() => board.on('transmit', transmitParsed))
       .then(() => board.on('close', disconnected))
       .tap(() => this._handleClear())
-      //.tap(() => this._watchConnection(board))
       .tap(() => this._handleSuccess(`'${name}' downloaded successfully`))
       .catch((err) => this._handleError(err))
       .finally(() => {

--- a/src/stores/device.js
+++ b/src/stores/device.js
@@ -157,7 +157,7 @@ class DeviceStore {
       .then(() => board.on('terminal', output))
       .then(() => board.on('terminal', rx))
       .then(() => board.on('transmit', transmitParsed))
-      .then(() => board.on('close', disconnected))
+      .tap(() => board.on('close', disconnected))
       .tap(() => this._handleClear())
       .tap(() => this._handleSuccess(`'${name}' downloaded successfully`))
       .catch((err) => this._handleError(err))

--- a/src/stores/transmission.js
+++ b/src/stores/transmission.js
@@ -2,14 +2,15 @@
 
 const alt = require('../alt');
 
-const { rx, tx } = require('../actions/transmission');
+const { rx, tx, transmitInput } = require('../actions/transmission');
 
 class TransmissionStore {
   constructor() {
 
     this.bindListeners({
       onRx: rx,
-      onTx: tx
+      onTx: tx,
+      onTransmitInput: transmitInput
     });
 
     this.state = {
@@ -53,6 +54,10 @@ class TransmissionStore {
 
       this.setState({ timeoutIdTx: id });
     }
+  }
+
+  onTransmitInput(input) {
+    // send input to STAMP
   }
 
 }

--- a/src/stores/transmission.js
+++ b/src/stores/transmission.js
@@ -2,15 +2,14 @@
 
 const alt = require('../alt');
 
-const { rx, tx, transmitInput } = require('../actions/transmission');
+const { rx, tx } = require('../actions/transmission');
 
 class TransmissionStore {
   constructor() {
 
     this.bindListeners({
       onRx: rx,
-      onTx: tx,
-      onTransmitInput: transmitInput
+      onTx: tx
     });
 
     this.state = {
@@ -54,10 +53,6 @@ class TransmissionStore {
 
       this.setState({ timeoutIdTx: id });
     }
-  }
-
-  onTransmitInput(input) {
-    // send input to STAMP
   }
 
 }

--- a/src/stores/transmission.js
+++ b/src/stores/transmission.js
@@ -2,7 +2,7 @@
 
 const alt = require('../alt');
 
-const { connected, disconnected, rx, tx, transmitInput } = require('../actions/transmission');
+const { connected, disconnected, rx, tx, transmitInput, transmitParsed } = require('../actions/transmission');
 const deviceStore = require('./device');
 
 class TransmissionStore {
@@ -13,7 +13,8 @@ class TransmissionStore {
       onDisconnected: disconnected,
       onRx: rx,
       onTx: tx,
-      onTransmitInput: transmitInput
+      onTransmitInput: transmitInput,
+      onTransmitParsed: transmitParsed
     });
 
     this.state = {
@@ -72,44 +73,31 @@ class TransmissionStore {
   onTransmitInput(input) {
 
     const { keyCode } = input.nativeEvent;
-    const keyCodeArr = new Uint8Array([keyCode]);
-
-    this._updateTransmitText(keyCode);
 
     const { selectedDevice } = deviceStore.getState();
     const { getBoard } = this.getInstance();
 
     const board = getBoard(selectedDevice);
 
-    board.write(keyCodeArr.buffer)
+    board.write(keyCode)
       .catch((err) => this._handleError(err));
   }
 
-  _updateTransmitText(keyCode) {
-
-    const key = String.fromCharCode(keyCode);
+  onTransmitParsed(input) {
     const { transmitText } = this.state;
 
     let updatedTransmitText = null;
-    const ignorePress = [16, 17, 18, 20];
 
-    if ((keyCode >= 32 && keyCode <= 127) ||
-        (keyCode >= 160 && keyCode <= 255)) {
-      updatedTransmitText = transmitText + key;
-    } else if (keyCode === 8) {
-      updatedTransmitText = transmitText.slice(0, -1);
-    } else if (keyCode === 10 || keyCode === 13) {
-      updatedTransmitText = transmitText + '\n';
-    } else if (ignorePress.indexOf(keyCode) > -1) {
-      return;
-    } else {
-      updatedTransmitText = transmitText + ' ';
-    }
+    input.forEach((ch) => {
+      if (ch.type === 'backspace') {
+        updatedTransmitText = transmitText.slice(0, -1);
 
-    this.setState({ transmitText: updatedTransmitText });
-
+      } else if (ch.type === 'text') {
+        updatedTransmitText = transmitText + ch.data;
+      }
+      this.setState({ transmitText: updatedTransmitText });
+    });
   }
-
 }
 
 TransmissionStore.config = {

--- a/src/stores/transmission.js
+++ b/src/stores/transmission.js
@@ -2,7 +2,7 @@
 
 const alt = require('../alt');
 
-const { connected, disconnected, rx, tx, transmitInput, transmitParsed } = require('../actions/transmission');
+const { connected, disconnected, rx, tx, transmitInput } = require('../actions/transmission');
 const deviceStore = require('./device');
 
 class TransmissionStore {
@@ -13,8 +13,7 @@ class TransmissionStore {
       onDisconnected: disconnected,
       onRx: rx,
       onTx: tx,
-      onTransmitInput: transmitInput,
-      onTransmitParsed: transmitParsed
+      onTransmitInput: transmitInput
     });
 
     this.state = {
@@ -23,14 +22,17 @@ class TransmissionStore {
       timeoutIdRx: null,
       timeoutIdTx: null,
       flashDuration: 50,
-      transmitText: '',
+      text: '',
       connected: false
     };
 
   }
 
   onConnected() {
-    this.setState({ connected: true });
+    this.setState({
+      text: '',
+      connected: true
+    });
   }
 
   onDisconnected() {
@@ -70,32 +72,35 @@ class TransmissionStore {
     }
   }
 
-  onTransmitInput(input) {
-
-    const { keyCode } = input.nativeEvent;
-
+  onTransmitInput(keyCode) {
     const { selectedDevice } = deviceStore.getState();
     const { getBoard } = this.getInstance();
 
     const board = getBoard(selectedDevice);
 
+    board.once('transmit', this._processEvent.bind(this));
+
     board.write(keyCode)
       .catch((err) => this._handleError(err));
   }
 
-  onTransmitParsed(input) {
-    const { transmitText } = this.state;
+  _processEvent(input) {
+    const { text } = this.state;
 
-    let updatedTransmitText = null;
-
-    input.forEach((ch) => {
-      if (ch.type === 'backspace') {
-        updatedTransmitText = transmitText.slice(0, -1);
-
-      } else if (ch.type === 'text') {
-        updatedTransmitText = transmitText + ch.data;
+    const newText = input.reduce((result, ch) => {
+      if(ch.type === 'backspace'){
+        return result.slice(0, -1);
       }
-      this.setState({ transmitText: updatedTransmitText });
+
+      if(ch.type === 'text'){
+        return result + ch.data;
+      }
+
+      return result;
+    }, text);
+
+    this.setState({
+      text: newText
     });
   }
 }

--- a/src/stores/transmission.js
+++ b/src/stores/transmission.js
@@ -70,16 +70,14 @@ class TransmissionStore {
     }
   }
 
-  onTransmitInput(input) {
-
-    const { keyCode } = input.nativeEvent;
+  onTransmitInput(val) {
 
     const { selectedDevice } = deviceStore.getState();
     const { getBoard } = this.getInstance();
 
     const board = getBoard(selectedDevice);
 
-    board.write(keyCode)
+    board.write(val)
       .catch((err) => this._handleError(err));
   }
 


### PR DESCRIPTION
#### What's this PR do?

Implements a transmit pane to support host-to-microcontroller communication, as defined in issue #76 and the attached document.
#### Where should the reviewer start?

Pull down this branch, remove node_modules, npm install - to get the latest updates to bs2-serial.
npm run build
#### How should this be manually tested?

The Transmit Pane is the new bar between the editor and the Receive Pane. Right away, you should not be able to click into the Transmit Pane because no devices are connected. Load in some test code that uses SERIN. Download the code to a BS2 device. As long as the connection is open the Transmit Pane will be active. 

While the connection is open, try typing text, paragraphs, long lines into the Transmit Pane. 
- Click back into already entered text. Press another key. 
- Press the backspace key. 
- Press the enter key.
- Press the shift/ctrl/caps lock/tab/alt keys
- Navigate with the arrow keys

Ensure the behavior around those events is as expected.

Disconnect your device. The Transmit Pane should become inactive. Connect and download again, the Pane should clear and reactive.
#### Any background context you want to provide?

The transmit pane is currently sending a Uint8 Buffer with ASCII codes to the device layer. The device layer seems to handle this well, as the characters representing those ASCII codes are displayed in the Receive Pane. 
#### What are the relevant tickets?

Closes #76 
#### Screenshots (if appropriate)

![image](https://cloud.githubusercontent.com/assets/2586086/8610725/ef7c047c-266a-11e5-9cfe-ffcc2115a539.png)
