### PR TITLE
Confirm Overwrite Logic and Overlay

### DIFF
--- a/plugins/overlays/overwrite-confirm.js
+++ b/plugins/overlays/overwrite-confirm.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const React = require('react');
+const Card = require('react-material/components/Card');
+const Button = require('react-material/components/Button');
+
+const styles = require('./styles');
+
+class OverwriteConfirmOverlay extends React.Component {
+  constructor(){
+    this.onAccept = this.onAccept.bind(this);
+    this.onCancel = this.onCancel.bind(this);
+  }
+
+  onAccept(){
+    const overwrite = true;
+    if(typeof this.props.onAccept === 'function'){
+      this.props.onAccept(this.props.name, overwrite);
+    }
+  }
+
+  onCancel(){
+    if(typeof this.props.onCancel === 'function'){
+      this.props.onCancel();
+    }
+  }
+
+  render(){
+    const filename = this.props.name;
+    return (
+      <Card styles={styles.overlay}>
+        <h3 style={styles.overlayTitle}>File {filename} already exists. Overwrite anyway?</h3>
+        <div style={styles.overlayButtonContainer}>
+          <Button onClick={this.onAccept}>Overwrite</Button>
+          <Button onClick={this.onCancel}>Cancel</Button>
+        </div>
+      </Card>
+    );
+  }
+}
+
+module.exports = OverwriteConfirmOverlay;

--- a/plugins/overlays/save.js
+++ b/plugins/overlays/save.js
@@ -52,11 +52,13 @@ class SaveOverlay extends React.Component {
 
   _onAccept(){
     const { onAccept, fileName } = this.props;
+    const overwrite = false;
+
+    if(typeof onAccept === 'function'){
+      onAccept(fileName, overwrite);
+    }
 
     clearName();
-    if(typeof onAccept === 'function'){
-      onAccept(fileName);
-    }
   }
 
   _onCancel(status){

--- a/src/actions/overlay.js
+++ b/src/actions/overlay.js
@@ -31,6 +31,14 @@ class OverlayActions {
     this.dispatch();
   }
 
+  showOverwrite(){
+    this.dispatch();
+  }
+
+  hideOverwrite(){
+    this.dispatch();
+  }
+
   showProjects(){
     this.dispatch();
   }

--- a/src/stores/overlay.js
+++ b/src/stores/overlay.js
@@ -13,6 +13,8 @@ const {
   hideDelete,
   showDownload,
   hideDownload,
+  showOverwrite,
+  hideOverwrite,
   showProjects,
   hideProjects,
   showProjectDelete } = require('../actions/overlay');
@@ -30,6 +32,8 @@ class OverlayStore {
       onHideDelete: [hideDelete, deleteFile],
       onShowDownload: showDownload,
       onHideDownload: hideDownload,
+      onShowOverwrite: showOverwrite,
+      onHideOverwrite: hideOverwrite,
       onShowProjects: [deleteProject, showProjects],
       onHideProjects: [changeProject, hideProjects],
       onShowProjectDelete: [confirmDelete, showProjectDelete]
@@ -39,6 +43,7 @@ class OverlayStore {
       showSaveOverlay: false,
       showDeleteOverlay: false,
       showDownloadOverlay: false,
+      showOverwriteOverlay: false,
       showProjectsOverlay: false,
       showProjectDeleteOverlay: false
     };
@@ -49,8 +54,27 @@ class OverlayStore {
       showSaveOverlay: false,
       showDeleteOverlay: false,
       showDownloadOverlay: false,
+      showOverwriteOverlay: false,
       showProjectsOverlay: false,
       showProjectDeleteOverlay: false
+    });
+  }
+
+  onShowOverwrite() {
+    this.setState({
+      showSaveOverlay: false,
+      showDeleteOverlay: false,
+      showDownloadOverlay: false,
+      showOverwriteOverlay: true,
+      showProjectsOverlay: false,
+      showProjectDeleteOverlay: false
+    });
+  }
+
+  onHideOverwrite() {
+    this.setState({
+      showOverwriteOverlay: false,
+      showSaveOverlay: true
     });
   }
 
@@ -78,6 +102,7 @@ class OverlayStore {
       showSaveOverlay: true,
       showDeleteOverlay: false,
       showDownloadOverlay: false,
+      showOverwriteOverlay: false,
       showProjectsOverlay: false,
       showProjectDeleteOverlay: false
     });
@@ -94,6 +119,7 @@ class OverlayStore {
       showSaveOverlay: false,
       showDeleteOverlay: true,
       showDownloadOverlay: false,
+      showOverwriteOverlay: false,
       showProjectsOverlay: false,
       showProjectDeleteOverlay: false
     });
@@ -110,6 +136,7 @@ class OverlayStore {
       showSaveOverlay: false,
       showDeleteOverlay: false,
       showDownloadOverlay: true,
+      showOverwriteOverlay: false,
       showProjectsOverlay: false,
       showProjectDeleteOverlay: false
     });
@@ -126,6 +153,7 @@ class OverlayStore {
       showSaveOverlay: false,
       showDeleteOverlay: false,
       showDownloadOverlay: false,
+      showOverwriteOverlay: false,
       showProjectsOverlay: true,
       showProjectDeleteOverlay: false
     });
@@ -143,6 +171,7 @@ class OverlayStore {
       showSaveOverlay: false,
       showDeleteOverlay: false,
       showDownloadOverlay: false,
+      showOverwriteOverlay: false,
       showProjectsOverlay: false,
       showProjectDeleteOverlay: true
     });


### PR DESCRIPTION
#### What's this PR do?

Adds overwrite protection to ChromeIDE, prompting for confirmation if a user attempts to save a file that already exists.
#### Where should the reviewer start?

Pull this branch.
npm run build
#### How should this be manually tested?

Create a few test files. Try to perform Save As on a file with a name that already exists - you should be prompted with an overlay that asks if you want to overwrite that file.  Choose overwrite.

Try to Save As another file that already exists. Choose cancel. You should be taken back to the Save As screen to rename your file.

Ensure normal Save and Save As are working as expected when not overwriting.
#### Any background context you want to provide?

There is currently a bug in this feature. Saving a file with the Overwrite functionality does not actually save the file at every level of file abstraction. It appears to save at the deeper levels, because restarting the app loads the saved file. But just clicking to the overwritten file will still show the old file. 
#### What are the relevant tickets?

Closes #168 
#### Screenshots (if appropriate)

![image](https://cloud.githubusercontent.com/assets/2586086/8610943/fd3e5986-266d-11e5-90e2-764d19e306bd.png)
