### PR TITLE
Key Capture Context

### DIFF
--- a/client.js
+++ b/client.js
@@ -39,6 +39,9 @@ const plugins = [
   },
   {
     register: require('./plugins/overlays')
+  },
+  {
+    register: require('./plugins/keys')
   }
 ];
 

--- a/plugins/editor/index.js
+++ b/plugins/editor/index.js
@@ -13,7 +13,7 @@ const React = require('react');
 const CodeMirror = require('codemirror');
 require('./pbasic')(CodeMirror);
 
-const keyExtension = require('./key-extension');
+const KeyExtension = require('./key-extension');
 
 const consoleStore = require('../../src/stores/console');
 const editorStore = require('../../src/stores/editor');
@@ -104,7 +104,7 @@ function editor(app, opts, done){
         'Shift-Tab': false,
         'Ctrl-T': false
       });
-      keyExtension.setup(app);
+
       editorStore.cm = codeEditor;
       fileStore.documents = new DocumentsStore(codeEditor);
     }

--- a/plugins/editor/key-extension.js
+++ b/plugins/editor/key-extension.js
@@ -147,20 +147,20 @@ class KeyExtension {
     };
 
     this.overlayCommands = {
-      enter: {
-        code: 'ENTER',
-        exec(evt){
-          evt.preventDefault();
-          saveFileAs();
-        }
-      },
-      hideOverlay: {
-        code: 'ESC',
-        exec: (evt) => {
-          evt.preventDefault();
-          hideOverlays();
-        }
-      }
+      // enter: {
+      //   code: 'ENTER',
+      //   exec(evt){
+      //     evt.preventDefault();
+      //     saveFileAs();
+      //   }
+      // },
+      // hideOverlay: {
+      //   code: 'ESC',
+      //   exec: (evt) => {
+      //     evt.preventDefault();
+      //     hideOverlays();
+      //   }
+      // }
     };
 
     this.customPredicates = {

--- a/plugins/keys/index.js
+++ b/plugins/keys/index.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const contextTypes = require('../../src/context-types');
+// Actions
+const { saveFileAs } = require('../../src/actions/file');
+const { hideOverlays } = require('../../src/actions/overlay');
+// Stores
+const contextStore = require('../../src/stores/context');
+
+const {
+  SAVE_AS_OVERLAY,
+  DELETE_OVERLAY
+} = contextTypes;
+
+function keys(app, opts, done){
+  const { ENTER, ESC } = app.keypress;
+
+  app.keypress(ENTER, function(evt){
+    const { type } = contextStore.getState();
+
+    switch(type){
+      case SAVE_AS_OVERLAY:
+        evt.preventDefault();
+        saveFileAs();
+        break;
+    }
+  });
+
+  app.keypress(ESC, function(evt){
+    const { type } = contextStore.getState();
+
+    switch(type){
+      case SAVE_AS_OVERLAY:
+      case DELETE_OVERLAY:
+        evt.preventDefault();
+        hideOverlays();
+        break;
+    }
+  });
+
+  done();
+}
+
+module.exports = keys;

--- a/plugins/overlays/index.js
+++ b/plugins/overlays/index.js
@@ -14,6 +14,11 @@ const { confirmDelete, changeProject, deleteProject } = require('../../src/actio
 const { deleteFile, saveFileAs } = require('../../src/actions/file');
 const { hideSave, hideDelete, hideDownload, showProjects, hideProjects } = require('../../src/actions/overlay');
 
+function keyAction(event) {
+  console.log('KEYACTION:', event);
+  event.stopPropagation();
+}
+
 function overlays(app, opts, done){
 
   const { overlay, workspace, userConfig } = app;
@@ -91,6 +96,15 @@ function overlays(app, opts, done){
       // if there is a change and every state is false, hide overlay
       overlay.hide();
     }
+
+    if (showSaveOverlay) {
+      document.addEventListener('keydown', keyAction, false);
+    }
+    else {
+      document.removeEventListener('keydown', keyAction, false);
+    }
+
+
   }
 
   overlayStore.listen(onOverlayChange);

--- a/plugins/overlays/index.js
+++ b/plugins/overlays/index.js
@@ -13,15 +13,15 @@ const projectStore = require('../../src/stores/project');
 const { confirmDelete, changeProject, deleteProject } = require('../../src/actions/project');
 const { deleteFile, saveFileAs } = require('../../src/actions/file');
 const { hideSave, hideDelete, hideDownload, showProjects, hideProjects } = require('../../src/actions/overlay');
-
-function keyAction(event) {
-  console.log('KEYACTION:', event);
-  event.stopPropagation();
-}
+const KeyExtension = require('../editor/key-extension');
 
 function overlays(app, opts, done){
 
   const { overlay, workspace, userConfig } = app;
+  let baseKeys = true;
+  let overlayKeys = false;
+  const keyExtension = new KeyExtension(app);
+  keyExtension.setBaseCommands();
 
   projectStore.config = userConfig;
   projectStore.workspace = workspace;
@@ -97,13 +97,19 @@ function overlays(app, opts, done){
       overlay.hide();
     }
 
-    if (showSaveOverlay) {
-      document.addEventListener('keydown', keyAction, false);
-    }
-    else {
-      document.removeEventListener('keydown', keyAction, false);
+    if (showSaveOverlay && !overlayKeys) {
+      keyExtension.removeBaseCommands();
+      keyExtension.setOverlayCommands();
+      overlayKeys = true;
+      baseKeys = false;
     }
 
+    if (!showSaveOverlay && !baseKeys) {
+      keyExtension.removeOverlayCommands();
+      keyExtension.setBaseCommands();
+      overlayKeys = false;
+      baseKeys = true;
+    }
 
   }
 

--- a/plugins/overlays/save.js
+++ b/plugins/overlays/save.js
@@ -40,9 +40,10 @@ class SaveOverlay extends React.Component {
           placeHolder="filename"
           styles={styles.textField}
           floatingLabel
+          tabIndex='1'
           onChange={this._onUpdateName} />
         <div style={styles.overlayButtonContainer}>
-          <Button onClick={this._onAccept}>Save As</Button>
+          <Button tabIndex='1' onClick={this._onAccept}>Save As</Button>
           <Button onClick={() => this._onCancel({ trash: true })}>Don't Save</Button>
           <Button onClick={() => this._onCancel({ trash: false })}>Cancel</Button>
         </div>
@@ -51,12 +52,12 @@ class SaveOverlay extends React.Component {
   }
 
   _onAccept(){
-    const { onAccept, fileName } = this.props;
+    const { onAccept } = this.props;
 
-    clearName();
     if(typeof onAccept === 'function'){
-      onAccept(fileName);
+      onAccept();
     }
+    clearName();
   }
 
   _onCancel(status){

--- a/plugins/sidebar/file-list.js
+++ b/plugins/sidebar/file-list.js
@@ -5,39 +5,6 @@ const List = require('react-material/components/List');
 
 const FileList = React.createClass({
 
-  componentDidMount: function(){
-    this.remove_nextFile = app.keypress(app.keypress.CTRL_TAB, this.nextFile);
-    this.remove_previousFile = app.keypress(app.keypress.CTRL_SHIFT_TAB, this.previousFile);
-  },
-  componentWillUnmount: function(){
-    if(this.remove_nextFile) {
-     this.remove_nextFile();
-    }
-    if(this.remove_previousFile) {
-     this.remove_previousFile();
-    }
-  },
-  previousFile: function(){
-    this.changeFile({ direction: 'prev' });
-  },
-  nextFile: function() {
-    this.changeFile({ direction: 'next' });
-  },
-  changeFile: function(move) {
-    const { workspace, loadFile } = this.props;
-    const filename = workspace.filename.deref();
-
-    workspace.directory.forEach(function(x, i) {
-      if(x.get('name') === filename) {
-        if(i === workspace.directory.size - 1) {
-          i = -1;
-        }
-        const shift = move.direction === 'prev' ? i - 1 : i + 1;
-        const switchFile = workspace.directory.getIn([shift, 'name']);
-        loadFile(switchFile);
-      }
-    });
-  },
   render: function(){
     return (
       <List>

--- a/src/actions/file.js
+++ b/src/actions/file.js
@@ -19,6 +19,14 @@ class FileActions {
     this.dispatch();
   }
 
+  nextFile() {
+    this.dispatch();
+  }
+
+  previousFile() {
+    this.dispatch();
+  }
+
   loadFile(filename){
     this.dispatch(filename);
   }

--- a/src/actions/overlay.js
+++ b/src/actions/overlay.js
@@ -46,6 +46,7 @@ class OverlayActions {
   hideProjectDelete(){
     this.dispatch();
   }
+
 }
 
 module.exports = alt.createActions(OverlayActions);

--- a/src/context-types.js
+++ b/src/context-types.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const contextTypes = {
+  SAVE_AS_OVERLAY: 'SAVE_AS_OVERLAY',
+  DELETE_OVERLAY: 'DELETE_OVERLAY'
+};
+
+module.exports = contextTypes;

--- a/src/stores/context.js
+++ b/src/stores/context.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const alt = require('../alt');
+const contextTypes = require('../context-types');
+// Actions
+const { loadFile, saveFile } = require('../actions/file');
+const { showSave } = require('../actions/overlay');
+// Stores
+const overlayStore = require('./overlay');
+
+const {
+  SAVE_AS_OVERLAY
+} = contextTypes;
+
+class ContextStore {
+  constructor(){
+    this.bindListeners({
+      onShowSaveAsOverlay: [loadFile, saveFile, showSave]
+    });
+
+    this.state = {
+      type: null
+    };
+  }
+
+  onShowSaveAsOverlay(){
+    // ugh anti-pattern
+    this.waitFor(overlayStore);
+
+    const { showSaveOverlay } = overlayStore.getState();
+
+    if(showSaveOverlay){
+      this.setState({ type: SAVE_AS_OVERLAY });
+    }
+  }
+
+}
+
+ContextStore.config = {
+  stateKey: 'state'
+};
+
+module.exports = alt.createStore(ContextStore);

--- a/src/stores/overlay.js
+++ b/src/stores/overlay.js
@@ -147,6 +147,7 @@ class OverlayStore {
       showProjectDeleteOverlay: true
     });
   }
+
 }
 
 OverlayStore.config = {


### PR DESCRIPTION
#### What's this PR do?

Separates key presses between normal operation and when the Save As overlay pops up. Allows the user to press Enter to Save a file, or Esc to close the overlay. Other key commands should be disabled when the Save As overlay is up.
#### Where should the reviewer start?

pull down the **Iggins** branch with the same name
npm run build
#### How should this be manually tested?

Create a test file. Try to Save As. With the Save As overlay open, try to press other key commands, such as Ctrl-N or Tab. Notice that none of our custom key commands will fire. Tab will no longer tab the editor, but it will try to tab through the page. This will be removed/moved to only the overlay in the next PR as this one was already getting too large.
#### Any background context you want to provide?

This is the base work for a few issues involving context of the editor. This only impacts the Save As overlay for now. If everything looks good here, I will move on to apply the same logic to the other overlays and navigation elements (such as using the arrow keys to move between files). 

There were a few ways to go about this change but in order to take advantage of our key press logic in Iggins, adding and removing keypresses as needed seemed like a good choice. The base key-extension.js file now supports this and can be extended for other context needs.
#### What are the relevant tickets?

References #126 
References #105 
References #104 
