### PR TITLE
Print styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,8 +47,8 @@
           visibility: hidden;
         }
 
-        .do-not-print {
-          display: none;
+        .mfb-component__button--child {
+          display: none !important;
         }
 
         #editorContainer,

--- a/index.html
+++ b/index.html
@@ -47,6 +47,10 @@
           visibility: hidden;
         }
 
+        .do-not-print {
+          display: none;
+        }
+
         #editorContainer,
         #editorContainer * {
           visibility: visible;

--- a/plugins/sidebar/index.js
+++ b/plugins/sidebar/index.js
@@ -45,7 +45,7 @@ function sidebar(app, opts, done){
           <ListItem icon="folder" disableRipple>{space.cwd.deref()}</ListItem>
           {directory.map((file) => <File key={file.get('name')} filename={file.get('name')} temp={file.get('temp')} loadFile={loadFile} />)}
         </FileList>
-        <FileOperations className="do-not-print"/>
+        <FileOperations />
       </Sidebar>
     );
 

--- a/plugins/sidebar/index.js
+++ b/plugins/sidebar/index.js
@@ -45,7 +45,7 @@ function sidebar(app, opts, done){
           <ListItem icon="folder" disableRipple>{space.cwd.deref()}</ListItem>
           {directory.map((file) => <File key={file.get('name')} filename={file.get('name')} temp={file.get('temp')} loadFile={loadFile} />)}
         </FileList>
-        <FileOperations />
+        <FileOperations className="do-not-print"/>
       </Sidebar>
     );
 


### PR DESCRIPTION
#### What's this PR do?

It removes the expanded file operations menu labels from appearing when printing.
#### Where should the reviewer start?

Pull the branch, install and build, and launch editor. The changes are in index.html and plugins/sidebar/index.js
#### How should this be manually tested?

In the editor, create a file, click the 'plus' button to expand the file menu and then 'cmd-p' or select print.  Notice in the print dialog that the preview does not have the labels appearing.
#### What are the relevant tickets?

closes #181
#### Screenshots (if appropriate)

This is what it looked like with the problem.
<img width="1230" alt="screen shot 2015-07-15 at 2 09 46 pm" src="https://cloud.githubusercontent.com/assets/1467882/8710761/137d1a7e-2b01-11e5-927f-17bdf1836624.png">

Here is what it looks with the issue resolved.
<img width="1234" alt="screen shot 2015-07-15 at 2 04 37 pm" src="https://cloud.githubusercontent.com/assets/1467882/8710766/219fde98-2b01-11e5-99c6-061d08725467.png">
