### PR TITLE
Implement tab in console store

### DIFF
--- a/src/stores/console.js
+++ b/src/stores/console.js
@@ -20,7 +20,7 @@ class ConsoleStore {
       length: 0,
       lines: [''],
       lineWrap: 256,
-      maxLines: 256,
+      maxLines: 2048,
       pointerLine: 0,
       pointerColumn: 0,
       refreshDelayMillis: 64,

--- a/src/stores/console.js
+++ b/src/stores/console.js
@@ -5,6 +5,8 @@ const _ = require('lodash');
 const alt = require('../alt');
 const { clearOutput, output } = require('../actions/console');
 
+const TAB_WIDTH = 8;
+
 class ConsoleStore {
   constructor() {
 
@@ -18,7 +20,7 @@ class ConsoleStore {
       length: 0,
       lines: [''],
       lineWrap: 256,
-      maxLines: 2048,
+      maxLines: 256,
       pointerLine: 0,
       pointerColumn: 0,
       refreshDelayMillis: 64,
@@ -133,6 +135,14 @@ class ConsoleStore {
     });
   }
 
+  tab(){
+    const { pointerColumn } = this.state;
+    const tabColumn = Math.floor(pointerColumn / TAB_WIDTH);
+    this.setState({
+      pointerColumn: (tabColumn + 1) * TAB_WIDTH
+    });
+  }
+
   processEvent(evt){
     const { pointerLine, pointerColumn } = this.state;
     switch(evt.type){
@@ -177,6 +187,9 @@ class ConsoleStore {
         break;
       case 'clear-below':
         this.clearBelow();
+        break;
+      case 'tab':
+        this.tab();
         break;
       default:
         console.log('Not yet implemented:', evt);


### PR DESCRIPTION
#### What's this PR do?

Implements TAB command functionality in receive terminal. This triggers when a device sends 0x9 (ASCII TAB) and should move the cursor position to the next 8-column delimited tab position.
#### What are the important parts of the code?

The `tab()` event in `stores/console.js` implements the actual cursor-positioning logic. The 0x9 was already being converted into a `tab` event within `bs2-protocol`, but wasn't implemented here yet.
#### How should this be tested by the reviewer?

Either add TAB debug events to code, or use the transmit pane with echo.
#### What are the relevant tickets? (Please add `closes`, `refs`, etc)

Closes parallaxinc/Parallax-IDE/issues/191
