### PR TITLE
Automatic download no match

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "alt": "^0.16.7",
-    "bs2-serial": "^0.10.0",
+    "bs2-serial": "^0.10.3",
     "codemirror": "^4.13.0",
     "frylord": "^0.6.0",
     "holovisor": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "alt": "^0.16.7",
-    "bs2-serial": "^0.10.4",
+    "bs2-serial": "^0.10.5",
     "codemirror": "^4.13.0",
     "frylord": "^0.6.0",
     "holovisor": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "alt": "^0.16.7",
-    "bs2-serial": "^0.10.3",
+    "bs2-serial": "^0.10.4",
     "codemirror": "^4.13.0",
     "frylord": "^0.6.0",
     "holovisor": "^0.2.0",

--- a/plugins/editor/index.js
+++ b/plugins/editor/index.js
@@ -106,9 +106,11 @@ function editor(app, opts, done){
         'Shift-Tab': false,
         'Ctrl-T': false
       });
+
       keyExtension.setup(app);
       editorStore.cm = codeEditor;
       fileStore.documents = new DocumentsStore(codeEditor);
+      deviceStore.cm = codeEditor;
     }
 
 

--- a/plugins/editor/index.js
+++ b/plugins/editor/index.js
@@ -109,8 +109,9 @@ function editor(app, opts, done){
 
       keyExtension.setup(app);
       editorStore.cm = codeEditor;
-      fileStore.documents = new DocumentsStore(codeEditor);
-      deviceStore.cm = codeEditor;
+      const documents = new DocumentsStore(codeEditor);
+      fileStore.documents = documents;
+      deviceStore.documents = documents;
     }
 
 

--- a/src/stores/device.js
+++ b/src/stores/device.js
@@ -76,7 +76,7 @@ class DeviceStore {
 
   onUpdateSelected(device) {
 
-    const { workspace, cm } = this.getInstance();
+    const { workspace, documents } = this.getInstance();
     const { noneMatched } = this.messages;
 
     if(this.state.message === noneMatched) {
@@ -88,12 +88,10 @@ class DeviceStore {
 
       const pre = source.substring(0, TargetStart);
       const post = source.substring(end, source.length);
-      const newsource = pre + name + post;
+      const newSource = pre + name + post;
 
-      //TODO: action -> action dispatch error
-      //editor should be set with new source
-      cm.getDoc().setValue(newsource);
-
+      documents.update(newSource);
+      workspace.updateContent(newSource);
     }
 
     this.setState({

--- a/src/stores/device.js
+++ b/src/stores/device.js
@@ -76,6 +76,25 @@ class DeviceStore {
 
   onUpdateSelected(device) {
 
+    const { workspace } = this.getInstance();
+    const { noneMatched } = this.messages;
+
+    if(this.state.message === noneMatched) {
+
+      const { name } = device;
+      const { TargetStart } = device.program.raw;
+      const end = source.indexOf('}', TargetStart);
+
+      const source = workspace.current.deref();
+
+      const pre = source.substring(0, TargetStart);
+      const post = source.substring(end, source.length);
+      const newsource = pre + name + post;
+
+      workspace.updateContent(newsource);
+
+    }
+
     this.setState({
       devicePath: device.path,
       selectedDevice: device,
@@ -106,7 +125,6 @@ class DeviceStore {
 
     } else if (matchedDevices.length === 0) {
 
-      //TODO: setup for part 4 of auto download issue
       this.setState({ message: noneMatched });
 
     } else if(matchedDevices.length === 1) {

--- a/src/stores/device.js
+++ b/src/stores/device.js
@@ -151,7 +151,6 @@ class DeviceStore {
       this.setState({ progress: progress });
     }
 
-
     const { workspace, getBoard } = this.getInstance();
     const { selectedDevice } = this.state;
 
@@ -170,7 +169,7 @@ class DeviceStore {
     board.on('progress', updateProgress.bind(this));
     board.on('progress', tx.bind(this));
 
-    board.bootload(selectedDevice.program)
+    board.bootload(workspace.current.deref())
       .tap(() => clearOutput())
       .then(() => board.on('terminal', output))
       .then(() => board.on('terminal', rx))

--- a/src/stores/device.js
+++ b/src/stores/device.js
@@ -76,22 +76,23 @@ class DeviceStore {
 
   onUpdateSelected(device) {
 
-    const { workspace } = this.getInstance();
+    const { workspace, cm } = this.getInstance();
     const { noneMatched } = this.messages;
 
     if(this.state.message === noneMatched) {
 
       const { name } = device;
       const { TargetStart } = device.program.raw;
-      const end = source.indexOf('}', TargetStart);
-
       const source = workspace.current.deref();
+      const end = source.indexOf('}', TargetStart);
 
       const pre = source.substring(0, TargetStart);
       const post = source.substring(end, source.length);
       const newsource = pre + name + post;
 
-      workspace.updateContent(newsource);
+      //TODO: action -> action dispatch error
+      //editor should be set with new source
+      cm.getDoc().setValue(newsource);
 
     }
 

--- a/src/stores/documents.js
+++ b/src/stores/documents.js
@@ -8,11 +8,20 @@ class DocumentsStore {
   constructor(editor){
     this._editor = editor;
 
+    this._filename = null;
     this._documents = {};
   }
 
   focus(){
     this._editor.focus();
+  }
+
+  update(text){
+    if(!this._filename){
+      return;
+    }
+
+    return this.create(this._filename, text);
   }
 
   create(filename, text){
@@ -24,6 +33,8 @@ class DocumentsStore {
   }
 
   swap(filename) {
+    this._filename = filename;
+
     const doc = this._documents[filename];
 
     if(!doc){


### PR DESCRIPTION
#### What's this PR do?

Rewrites the source code if no matching BS2s are available but a different BS2 is and is selected.  Then recompiles the source and programs the device.
#### What are the important parts of the code?

`src/stores/documents` needed an `update` method and to track the current filename so we could alter the source code without causing a change event on CodeMirror.  `src/stores/device` is where the source code replacement is happening.  Not sure if that is the best place for it but it works for the current implementation.
#### How should this be tested by the reviewer?

Create a new program but change the stamp directive to `BS2e`, connect your BS2, attempt to download.  You should get the "No Matching Devices" message.  Then, manually select the BS2, your source code should have the stamp directive change and your device will be programmed.
#### Is any other information necessary to understand this?

Also, note that this is a temp file changed and isn't saved to disk unless the user explicitly saves.
#### What are the relevant tickets? (Please add `closes`, `refs`, etc)

Closes #166 
