### PR TITLE
Text overwrite and automatic word wrap in receive pane

### DIFF
--- a/src/lib/terminal.js
+++ b/src/lib/terminal.js
@@ -168,25 +168,43 @@ class Terminal {
   }
 
   addText(data){
-    const { lines, pointerLine, pointerColumn, trimCount, maxLines } = this.state;
-    const line = lines[pointerLine] || '';
-    if(pointerColumn < line.length){
-      const start = line.slice(0, pointerColumn);
-      const end = line.slice(pointerColumn + data.length);
-      lines[pointerLine] = start + data + end;
-    }else if(pointerColumn > line.length){
-      lines[pointerLine] = _.padRight(line, pointerColumn) + data;
-    }else{
-      lines[pointerLine] = line + data;
+    const { lines, lineWrap, pointerLine, pointerColumn, trimCount, maxLines } = this.state;
+
+    var newPointerColumn = pointerColumn;
+    var newPointerLine = pointerLine;
+    var newText = data;
+
+    while(newText.length > 0){
+      var oldLine = lines[newPointerLine] || '';
+      var initial = _.padRight(oldLine.slice(0, newPointerColumn), newPointerColumn);
+
+      var newData = newText.slice(0, lineWrap - initial.length);
+
+      var remainder = oldLine.slice(newData.length + initial.length);
+
+      var leftOver = newText.slice(lineWrap - initial.length);
+
+      lines[newPointerLine] = initial + newData + remainder;
+
+      console.log(lines[newPointerLine].length, leftOver.length, newPointerLine, newPointerColumn);
+
+      newText = leftOver;
+      if(newText.length > 0){
+        newPointerLine++;
+        newPointerColumn = 0;
+      }else{
+        newPointerColumn = initial.length + newData.length;
+      }
     }
 
     if(lines.length > maxLines){
       const newLines = lines.slice(trimCount);
       this.state.lines = newLines;
-      this.state.pointerLine = Math.max(0, pointerLine - trimCount);
-      this.state.pointerColumn = pointerColumn + data.length;
+      this.state.pointerLine = Math.max(0, newPointerLine - trimCount);
+      this.state.pointerColumn = newPointerColumn;
     } else {
-      this.state.pointerColumn = pointerColumn + data.length;
+      this.state.pointerLine = newPointerLine;
+      this.state.pointerColumn = newPointerColumn;
     }
   }
 

--- a/src/lib/terminal.js
+++ b/src/lib/terminal.js
@@ -167,42 +167,40 @@ class Terminal {
     }
   }
 
-  addText(data){
-    const { lines, lineWrap, pointerLine, pointerColumn, trimCount, maxLines } = this.state;
+  addText(newText){
+    const { lines, lineWrap, trimCount, maxLines } = this.state;
 
-    var newPointerColumn = pointerColumn;
-    var newPointerLine = pointerLine;
-    var newText = data;
+    let { pointerColumn, pointerLine } = this.state;
 
     while(newText.length > 0){
-      var oldLine = lines[newPointerLine] || '';
-      var initial = _.padRight(oldLine.slice(0, newPointerColumn), newPointerColumn);
+      let oldLine = lines[pointerLine] || '';
+      let initial = _.padRight(oldLine.slice(0, pointerColumn), pointerColumn);
 
-      var newData = newText.slice(0, lineWrap - initial.length);
+      let insert = newText.slice(0, Math.max(lineWrap - initial.length, 0));
 
-      var remainder = oldLine.slice(newData.length + initial.length);
+      let remainder = oldLine.slice(insert.length + initial.length);
 
-      var leftOver = newText.slice(lineWrap - initial.length);
+      let leftOver = newText.slice(insert.length);
 
-      lines[newPointerLine] = initial + newData + remainder;
+      lines[pointerLine] = initial + insert + remainder;
 
       newText = leftOver;
       if(newText.length > 0){
-        newPointerLine++;
-        newPointerColumn = 0;
+        pointerLine++;
+        pointerColumn = 0;
       }else{
-        newPointerColumn = initial.length + newData.length;
+        pointerColumn = initial.length + insert.length;
       }
     }
 
     if(lines.length > maxLines){
       const newLines = lines.slice(trimCount);
       this.state.lines = newLines;
-      this.state.pointerLine = Math.max(0, newPointerLine - trimCount);
-      this.state.pointerColumn = newPointerColumn;
+      this.state.pointerLine = Math.max(0, pointerLine - trimCount);
+      this.state.pointerColumn = pointerColumn;
     } else {
-      this.state.pointerLine = newPointerLine;
-      this.state.pointerColumn = newPointerColumn;
+      this.state.pointerLine = pointerLine;
+      this.state.pointerColumn = pointerColumn;
     }
   }
 

--- a/src/lib/terminal.js
+++ b/src/lib/terminal.js
@@ -172,7 +172,7 @@ class Terminal {
     const line = lines[pointerLine] || '';
     if(pointerColumn < line.length){
       const start = line.slice(0, pointerColumn);
-      const end = line.slice(pointerColumn);
+      const end = line.slice(pointerColumn + data.length);
       lines[pointerLine] = start + data + end;
     }else if(pointerColumn > line.length){
       lines[pointerLine] = _.padRight(line, pointerColumn) + data;

--- a/src/lib/terminal.js
+++ b/src/lib/terminal.js
@@ -186,8 +186,6 @@ class Terminal {
 
       lines[newPointerLine] = initial + newData + remainder;
 
-      console.log(lines[newPointerLine].length, leftOver.length, newPointerLine, newPointerColumn);
-
       newText = leftOver;
       if(newText.length > 0){
         newPointerLine++;

--- a/src/views/terminal.js
+++ b/src/views/terminal.js
@@ -15,7 +15,7 @@ const styles = {
     padding: '10px',
     margin: '0',
     overflow: 'auto',
-    whiteSpace: 'pre-wrap'
+    whiteSpace: 'pre'
   }
 };
 


### PR DESCRIPTION
#### What's this PR do?

This PR addresses issues raised in #201 and #203. The receive pane now automatically overwrites text when the cursor is not at the end and automatically wraps lines after 256 characters.
#### What are the important parts of the code?

The important change is to `addText` in the terminal store, the updated console logic handles line wrap and overwrite.
#### How should this be tested by the reviewer?

Run the code mentioned in #201 and verify other text functionality still functions as expected with this older test program: https://gist.github.com/2fast2fourier/dc7748f98a676094b6f8
#### Is any other information necessary to understand this?

This also disables automatic line wrap in the terminal viewport, as this was causing early line wrap in some cases.
#### What are the relevant tickets? (Please add `closes`, `refs`, etc)

Closes #200
Closes #201 
Closes #203 
