### PR TITLE
Improve clear-down to avoid accidental scrolling

### DIFF
--- a/src/lib/terminal.js
+++ b/src/lib/terminal.js
@@ -103,8 +103,9 @@ class Terminal {
 
   clearBelow(){
     const { lines, pointerLine } = this.state;
-    const newLines = lines.slice(0, Math.min(pointerLine + 1, lines.length));
-    this.state.lines = newLines;
+    for(let ix = pointerLine+1; ix < lines.length; ix++){
+      lines[ix] = '';
+    }
   }
 
   tab(){

--- a/src/lib/terminal.js
+++ b/src/lib/terminal.js
@@ -103,9 +103,7 @@ class Terminal {
 
   clearBelow(){
     const { lines, pointerLine } = this.state;
-    for(let ix = pointerLine+1; ix < lines.length; ix++){
-      lines[ix] = '';
-    }
+    _.fill(lines, '', pointerLine + 1, lines.length);
   }
 
   tab(){


### PR DESCRIPTION
#### What's this PR do?

This PR fixes an issue where the `CLRDN` command would accidentally scroll the screen by the number of lines cleared.
#### How should this be tested by the reviewer?

Simple test case:

```
'{$STAMP BS2}
'{$PBASIC 2.5}

Delay CON 1000

DEBUG "Start",CR,LF
PAUSE Delay
DEBUG "Clear Lines Below:",LF,CR,"<>",CR,LF,"<>",CR,LF,"<>"
PAUSE Delay
DEBUG CRSRUP,CRSRUP,CRSRUP,CLRDN
PAUSE Delay
DEBUG CR,"Done",CR
```
#### Is any other information necessary to understand this?

This issue is due to how the previous `CLRDN` implementation worked, it would remove the lines from the backing store, but with the newer scroll implementation that would cause the text to jump down.
#### What are the relevant tickets?

Closes #212 
