### PR TITLE
Terminal Receive pane scrolling improvements and buffer increase

### DIFF
--- a/src/creators/receive.js
+++ b/src/creators/receive.js
@@ -4,11 +4,12 @@ const {
   RECEIVE
 } = require('../constants/action-types');
 
-function receive(output){
+function receive(output, offset){
   return {
     type: RECEIVE,
     payload: {
-      output
+      output,
+      offset
     }
   };
 }

--- a/src/lib/scroller.js
+++ b/src/lib/scroller.js
@@ -45,8 +45,8 @@ Scroller.prototype.setLines = function(newLines, offset) {
   this.lines = newLines;
   this.lineOffset = offset;
   if(this.sticky){
-    this.startPosition = Math.max(this.lineOffset, this.lineCount() - this.visibleCount);
     this.endPosition = this.lineCount();
+    this.startPosition = Math.max(this.lineOffset, this.endPosition - this.visibleCount);
     if(this.endPosition <= this.visibleCount){
       // follow text during initial 50 lines
       this.jumpToBottom = true;
@@ -71,8 +71,8 @@ Scroller.prototype.lineCount = function(){
 };
 
 Scroller.prototype.reset = function(){
-  this.startPosition = Math.max(0, this.lineCount() - this.visibleCount);
   this.endPosition = Math.max(0, this.lineCount());
+  this.startPosition = Math.max(0, this.endPosition - this.visibleCount);
   this.lineOffset = 0;
   this.jumpToBottom = true;
   this.sticky = true;
@@ -90,8 +90,8 @@ Scroller.prototype._renderVisible = function(){
   if(this.dirty && this.console){
     const top = this.console.scrollTop;
     if(this.sticky){
-      this.startPosition = Math.max(this.lineOffset, this.lineCount() - this.visibleCount);
       this.endPosition = this.lineCount();
+      this.startPosition = Math.max(this.lineOffset, this.endPosition - this.visibleCount);
     }
     this.console.innerHTML = this._generateContent();
     if(this.jumpToBottom){

--- a/src/lib/scroller.js
+++ b/src/lib/scroller.js
@@ -13,6 +13,7 @@ function Scroller(consoleElement) {
   this.jumpToBottom = true;
   this.dirty = false;
   this.console = consoleElement;
+  this.expandDistance = 200;
 
   //pre-bind functions and throttle expansion
   this.refresh = this._renderVisible.bind(this);
@@ -155,8 +156,8 @@ Scroller.prototype._onScroll = function(){
   const height = this.console.offsetHeight;
   const scrollHeight = this.console.scrollHeight;
   const scrollTop = this.console.scrollTop;
-  const nearTop = scrollTop < 100;
-  const nearBottom = scrollTop + height > scrollHeight - 100;
+  const nearTop = scrollTop < this.expandDistance;
+  const nearBottom = scrollTop + height > scrollHeight - this.expandDistance;
   const nearSticky = scrollTop + height > scrollHeight - 10;
 
   if(this.sticky){

--- a/src/lib/terminal.js
+++ b/src/lib/terminal.js
@@ -11,7 +11,7 @@ class Terminal {
       lines: [''],
       lineWrap: 256,
       lineOffset: 0,
-      maxLines: 8096,
+      maxLines: 10000,
       pointerLine: 0,
       pointerColumn: 0,
       refreshDelayMillis: 64,

--- a/src/lib/terminal.js
+++ b/src/lib/terminal.js
@@ -10,7 +10,8 @@ class Terminal {
       lastRefresh: 0,
       lines: [''],
       lineWrap: 256,
-      maxLines: 2048,
+      lineOffset: 0,
+      maxLines: 8096,
       pointerLine: 0,
       pointerColumn: 0,
       refreshDelayMillis: 64,
@@ -31,6 +32,7 @@ class Terminal {
     const { refreshQueued } = this.state;
 
     this.state.lines = [''];
+    this.state.lineOffset = 0;
     this.state.pointerLine = 0;
     this.state.pointerColumn = 0;
 
@@ -68,7 +70,7 @@ class Terminal {
 
   setCursorPosition(line, col){
     const { lines } = this.state;
-    for(var ix = lines.length; ix <= line; ix++){
+    for(let ix = lines.length; ix <= line; ix++){
       lines[ix] = '';
     }
     this.state.pointerLine = Math.max(0, line);
@@ -196,6 +198,7 @@ class Terminal {
     if(lines.length > maxLines){
       const newLines = lines.slice(trimCount);
       this.state.lines = newLines;
+      this.state.lineOffset = this.state.lineOffset + trimCount;
       this.state.pointerLine = Math.max(0, pointerLine - trimCount);
       this.state.pointerColumn = pointerColumn;
     } else {
@@ -206,6 +209,10 @@ class Terminal {
 
   getLines(){
     return this.state.lines;
+  }
+
+  getOffset(){
+    return this.state.lineOffset;
   }
 
 }

--- a/src/plugins/handlers.js
+++ b/src/plugins/handlers.js
@@ -403,7 +403,8 @@ function handlers(app, opts, done){
   function updateTerminal(msg){
     terminal.refreshBuffer(msg, function(){
       const output = terminal.getLines();
-      store.dispatch(creators.receive(output));
+      const offset = terminal.getOffset();
+      store.dispatch(creators.receive(output, offset));
     });
   }
 

--- a/src/reducers/transmission.js
+++ b/src/reducers/transmission.js
@@ -12,7 +12,9 @@ const {
 const initial = {
   input: '',
   // output is an array of lines
-  output: []
+  output: [],
+  // offset is number of lines cleared from console buffer
+  offset: 0
 };
 
 function transmission(state = initial, { type, payload }){
@@ -20,7 +22,7 @@ function transmission(state = initial, { type, payload }){
     case CONNECT:
       return _.assign({}, state, { input: '' });
     case RECEIVE:
-      return _.assign({}, state, { output: payload.output });
+      return _.assign({}, state, { output: payload.output, offset: payload.offset });
     case TRANSMIT:
       return _.assign({}, state, { input: payload.input });
     case CLEAR_TRANSMISSION:

--- a/src/views/terminal.js
+++ b/src/views/terminal.js
@@ -22,8 +22,8 @@ const styles = {
 class TermnialView extends React.Component {
 
   componentWillReceiveProps(nextProps){
-    const { output } = nextProps;
-    this.scroller.setLines(output);
+    const { output, offset } = nextProps;
+    this.scroller.setLines(output, offset);
     this.scroller.requestRefresh();
   }
 
@@ -72,13 +72,14 @@ module.exports = createContainer(TermnialView, {
 
   getPropsFromStores({ store }){
     const { transmission, device } = store.getState();
-    const { input, output } = transmission;
+    const { input, output, offset } = transmission;
     const { connected } = device;
 
     return {
       connected,
       input,
-      output
+      output,
+      offset
     };
   }
 });


### PR DESCRIPTION
#### What's this PR do?

This PR improves terminal scroll-back to eliminate the performance hit from scrolling backwards in the console. This also increases the buffer size. Additionally, it prevents one form of 'text slipping' when the underlying buffer trims output by maintaining a line offset, now the console text will remain in place as long as the visible text does not fall outside the buffer storage.
#### What are the important parts of the code?

The primary scrolling changes are in the scrolling management class in `lib/scroller.js`. There were minor changes to the console buffer store, increasing buffer size and tracking trim offsets.
#### How should this be tested by the reviewer?

Try scrolling up and down to see how the console reacts. Here's a simple program to generate constant output:

```
'{$STAMP BS2}
'{$PBASIC 2.5}

  PAUSE 1000
  ix VAR WORD
  ix = 0

  DO
    DEBUG "Loop: ", DEC ix, CR
    ix = ix+1
    PAUSE 5
  LOOP
```
#### What are the relevant tickets?

Closes #202 
Closes #199 
