### PR TITLE
Improve scrolling functionality

### DIFF
--- a/src/lib/scroller.js
+++ b/src/lib/scroller.js
@@ -15,17 +15,11 @@ function Scroller(consoleElement) {
   this.console = consoleElement;
   this.expandDistance = 200;
 
-  //pre-bind functions and throttle expansion
+  //pre-bind functions
   this.refresh = this._renderVisible.bind(this);
   this.scroll = this._onScroll.bind(this);
-  this.expandTop = _.throttle(this._expandTop.bind(this), 150, {
-    leading: true,
-    trailing: true
-  });
-  this.expandBottom = _.throttle(this._expandBottom.bind(this), 150, {
-    leading: true,
-    trailing: true
-  });
+  this.expandTop = this._expandTop.bind(this);
+  this.expandBottom = this._expandBottom.bind(this);
 }
 
 Scroller.prototype._generateContent = function(){
@@ -89,7 +83,6 @@ Scroller.prototype.requestRefresh = function(){
 Scroller.prototype._renderVisible = function(){
   this.animateRequest = null;
   if(this.dirty && this.console){
-    const top = this.console.scrollTop;
     if(this.sticky){
       this.endPosition = this.lineCount();
       this.startPosition = Math.max(this.lineOffset, this.endPosition - this.visibleCount);
@@ -98,9 +91,6 @@ Scroller.prototype._renderVisible = function(){
     if(this.jumpToBottom){
       this.console.scrollTop = 4000;
       this.jumpToBottom = false;
-    }else if(!this.sticky && this.startPosition > this.lineOffset && top === this.lineOffset){
-      //cover the situation where the window was fully scrolled faster than expand could keep up and locked to the top
-      requestAnimationFrame(this.expandTop);
     }
     this.dirty = false;
   }

--- a/src/lib/scroller.js
+++ b/src/lib/scroller.js
@@ -42,8 +42,8 @@ Scroller.prototype.setLines = function(newLines, offset) {
   if(this.sticky){
     this.endPosition = this.lineCount();
     this.startPosition = Math.max(this.lineOffset, this.endPosition - this.visibleCount);
-    if(this.endPosition <= this.visibleCount){
-      // follow text during initial 50 lines
+    if(this.endPosition <= this.visibleCount * 2){
+      // follow text during initial lines (console can show up to twice the visibleCount when expanding)
       this.jumpToBottom = true;
     }
   }else if(newLines.length === 1 && newLines[0].length === 0){


### PR DESCRIPTION
#### What's this PR do?

This PR removes the throttling for expansion calls, allowing the scrolling window to keep up with very fast flings.
#### What are the important parts of the code?

The `expandTop` and `expandBottom` calls were throttled, but this meant it would fail to keep up when scrolling very fast. This would cause situations where scrolling momentum would be killed during a large fling gesture.
#### How should this be tested by the reviewer?

Scrolling around a console, example code:

```
'{$STAMP BS2}
'{$PBASIC 2.5}

  PAUSE 1000
  ix VAR WORD
  ix = 0

  DO
    DEBUG "Loop: ", DEC ix, CR
    ix = ix+1
    PAUSE 10
  LOOP
```
#### Is any other information necessary to understand this?

This also removes a workaround required to fix a specific edge-case when expansion was throttled.
#### What are the relevant tickets?

Refs #255 
