### PR TITLE
Add 3rem height to device list rows

### DIFF
--- a/src/views/download-overlay.js
+++ b/src/views/download-overlay.js
@@ -38,6 +38,9 @@ const styles = {
     verticalAlign: 'bottom',
     fontWeight: 'bold'
   },
+  deviceTr:{
+    height: '3rem'
+  },
   deviceTd: {
     padding: '8px 8px 8px 0',
     borderSpacing: 'collapse',
@@ -113,8 +116,9 @@ class DownloadOverlay extends React.Component {
     } = handlers;
 
     const highlight = device.path === path ? 'active' : 'inactive';
+    const deviceRowStyle = _.assign({}, styles.deviceTr, styles[highlight]);
     return (
-      <tr style={styles[highlight]} onClick={() => selectDevice(device)}>
+      <tr style={deviceRowStyle} onClick={() => selectDevice(device)}>
         <td style={styles.deviceTd}>{device.name}</td>
         <td style={styles.deviceTd}>{device.version}</td>
         <td style={styles.deviceTd}>{device.path}</td>


### PR DESCRIPTION
#### What's this PR do?

It adds a fixed height to the device list rows while ensuring that existing highlighting for active rows is maintained.
#### What are the important parts of the code?

take a look at views/download-overlay.js in the `styles` object and in the `componentizeDevice` function.
#### How should this be tested by the reviewer?

download, build, and relaunch the app.  Open the download or identify dialog and see the new row height.
#### What are the relevant tickets? (Please add `closes`, `refs`, etc)

closes #250
#### Screenshots (if appropriate)

Image from Windows 8.1 via Virtualbox
![Image from Windows 8.1 via Virtualbox](https://cloud.githubusercontent.com/assets/1467882/9805346/e3f58750-57ec-11e5-95ce-bbee0e793729.png)
