### PR TITLE
save prefs on changeFile

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "react-mfb-iceddev": "^0.1.0",
     "react-style": "^0.4.0",
     "skrim": "0.0.3",
-    "snacks": "^0.3.0",
+    "snacks": "^0.3.1",
     "sovereign": "^0.3.0",
     "when": "^3.7.2"
   },

--- a/src/plugins/handlers.js
+++ b/src/plugins/handlers.js
@@ -192,6 +192,7 @@ function handlers(app, opts, done){
     const doc = documents.swap(path.join(cwd, filename));
     if(doc){
       workspace.changeFile(filename)
+        .then(() => userConfig.set('last-file', filename))
         .then(() => workspace.updateContent(doc.getValue()))
         .then(function(){
           documents.focus();


### PR DESCRIPTION
#### What's this PR do?

Updates preferences when switching from a new file without saving it.
#### Where should the reviewer start?

in handlers.js one liner fix
#### How should this be manually tested?

build, 
load, 
start the app make sure its on a file that exits. 
close app
open app, should show existing file.
Create new file
switch to the file you started with, select Don't Save while changing files
Close app
re open should be on file you switched to.
#### What are the relevant tickets?

fixes #248 
