### PR TITLE
add directive builder function and modify newFile handler

### DIFF
--- a/src/lib/directive.js
+++ b/src/lib/directive.js
@@ -1,0 +1,15 @@
+'use strict';
+
+function device(type){
+  return `'{$STAMP ${type}}`;
+}
+
+function pbasic(ver){
+  return `'{$PBASIC ${ver}}`;
+}
+
+function directive(board, language){
+  return `${device(board)}\n${pbasic(language)}\n\n`;
+}
+
+module.exports = directive;

--- a/src/plugins/handlers.js
+++ b/src/plugins/handlers.js
@@ -12,6 +12,7 @@ const consoleStore = require('../console-store');
 const Terminal = require('../lib/terminal');
 const Documents = require('../lib/documents');
 const highlighter = require('../lib/highlighter');
+const directive = require('../lib/directive');
 
 const {
   NEW_FILE,
@@ -102,11 +103,14 @@ function handlers(app, opts, done){
       return;
     }
 
-    workspace.newFile(builtName, '')
+    const insertDirective = directive('BS2', 2.5);
+
+    workspace.newFile(builtName, insertDirective)
       .then(() => userConfig.set('last-file', builtName))
       .then(function(){
-        documents.create(path.join(cwd, builtName), '');
+        documents.create(path.join(cwd, builtName), insertDirective);
         documents.focus();
+        goDocEnd();
       });
   }
 
@@ -290,6 +294,10 @@ function handlers(app, opts, done){
 
   function replace(){
     cm.execCommand('replace');
+  }
+
+  function goDocEnd(){
+    cm.execCommand('goDocEnd');
   }
 
   function moveByScrollUpLine(){


### PR DESCRIPTION
#### What's this PR do?

Adds functionality to automatically add directives into new files.
#### What are the important parts of the code?

Adds a directive builder function that takes a board type and language.  When a newFIle is created the directive builder sets the contents of the temp file and the value in the document to the directive.  Once the directive is inserted and the editor is focused, there is a call to move the cursor to the end of the document. 
#### How should this be tested by the reviewer?

Download branch, launch editor and create new files.  Notice that the cursor position is placed below the directive to begin coding immediately. Notice that on navigating away you are prompted to save.
#### What are the relevant tickets? (Please add `closes`, `refs`, etc)

closes #253 
#### Screenshots (if appropriate)

<img width="347" alt="screen shot 2015-09-11 at 12 39 38 pm" src="https://cloud.githubusercontent.com/assets/1467882/9862256/77af6b30-5aec-11e5-9a54-c70c6c9d977a.png">
