### PR TITLE
simplify versioning process with a lifecycle script

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const fs = require('fs');
+
 const del = require('del');
 const gulp = require('gulp');
 const chalk = require('chalk');
@@ -41,6 +43,15 @@ function postinstall(cb){
   del('node_modules/**/*.pem', cb);
 }
 
+function version(cb){
+  const pkg = require('./package.json');
+  const manifest = require('./manifest.json');
+  manifest.version = pkg.version;
+  const content = `${JSON.stringify(manifest, null, 2)}\n`;
+  fs.writeFile('./manifest.json', content, cb);
+}
+
+gulp.task(version);
 gulp.task(release);
 gulp.task(postinstall);
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "test": "zuul test/*.js --local --open",
     "ci": "zuul test/*.js --electron",
     "build": "gulp",
+    "version": "gulp version && git add manifest.json",
     "release": "gulp gh-release",
     "postinstall": "gulp postinstall",
     "serve": "webpack-dev-server"


### PR DESCRIPTION
#### What's this PR do?

Adds a gulp task that rewrites the `manifest.json` file using the current version from the `package.json` file.  Also sets up an npm lifecycle hook for `version` that runs the gulp task and stages the change to be committed.
#### What are the important parts of the code?

The `version` function in `gulpfile.babel.js` is where the logic happens.
#### How should this be tested by the reviewer?

Pull down this branch and run `npm version patch`.  Check the files that we committed (using something like `gitk`) and verify that the version was increased to `0.8.2` in both the `package.json` and `manifest.json`.  **Once completed, make sure to use `git reset HEAD~1 --hard` to remove the version commit on that branch AND `git tag -d v0.8.2` to remove the tag that npm creates.** This is very important to do because we don't want accidental tags pushed.  
#### Is any other information necessary to understand this?

More info on the npm `version` lifecycle hook is available at https://docs.npmjs.com/cli/version
#### What are the relevant tickets? (Please add `closes`, `refs`, etc)

Closes #271 
