### PR TITLE
get cursor to be to the right of the text in the save overlay input

### DIFF
--- a/src/views/save-overlay.js
+++ b/src/views/save-overlay.js
@@ -98,7 +98,7 @@ class SaveOverlay extends React.Component {
   }
 
   focusInput() {
-    const input = React.findDOMNode(this.refs.filename).getElementsByTagName('input')[0]
+    const input = React.findDOMNode(this.refs.filename).getElementsByTagName('input')[0];
     const val = input.value;
     input.value = '';
     input.focus();

--- a/src/views/save-overlay.js
+++ b/src/views/save-overlay.js
@@ -98,7 +98,11 @@ class SaveOverlay extends React.Component {
   }
 
   focusInput() {
-    React.findDOMNode(this.refs.filename).getElementsByTagName('input')[0].focus();
+    const input = React.findDOMNode(this.refs.filename).getElementsByTagName('input')[0]
+    const val = input.value;
+    input.value = '';
+    input.focus();
+    input.value = val;
   }
 
   render(){


### PR DESCRIPTION
#### What's this PR do?

Gets the cursor to the right of the text in the save overlay.  This is achieved by removing the text before focus and then putting it back after (yay web :unamused:)
#### What are the important parts of the code?

The `focusInput` method of `src/views/save-overlay.js` has been modified to do what was described above.
#### How should this be tested by the reviewer?

Try the different methods of opening the save dialog (change file, cmd+shift+s, etc) and verify the cursor is always to the right.
#### Is any other information necessary to understand this?

Nope.
#### What are the relevant tickets? (Please add `closes`, `refs`, etc)

Closes #204 
