### PR TITLE
Use new break APIs, remove dependency on browser-serialport in webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@phated/redux-create-store": "^0.3.0",
-    "bs2-serial": "git://github.com/irkenjs/bs2-serial#experimental-break",
+    "bs2-serial": "^0.14.0",
     "codemirror": "^4.13.0",
     "frylord": "^0.7.4",
     "holovisor": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@phated/redux-create-store": "^0.3.0",
-    "bs2-serial": "^0.12.0",
+    "bs2-serial": "git://github.com/irkenjs/bs2-serial#experimental-break",
     "codemirror": "^4.13.0",
     "frylord": "^0.7.4",
     "holovisor": "^0.2.0",
@@ -30,7 +30,6 @@
     "babel-core": "^4.5.1",
     "babel-loader": "^4.0.0",
     "babel-runtime": "^4.7.16",
-    "browser-serialport": "git://github.com/garrows/browser-serialport#update",
     "chalk": "^1.0.0",
     "css-loader": "^0.9.1",
     "del": "^1.1.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -55,8 +55,7 @@ module.exports = {
     // inside a symlinked subdependency
     root: path.join(__dirname, 'node_modules'),
     alias: {
-      memdown: 'level-js',
-      serialport: 'browser-serialport'
+      memdown: 'level-js'
     }
   },
   bail: true,


### PR DESCRIPTION
#### What's this PR do?

Removes browser-serialport from webpack build.
#### How should this be tested by the reviewer?

Run a clean build, execute various test programs to verify programming functionality works as expected.
#### Is any other information necessary to understand this?

`chrome.serial` support is now contained in the transport class in `bs2-serial-protocol` and will be broken into a separate module later.
#### What are the relevant tickets?

Closes #144
