### PR TITLE
show project overlay upon delete, show notification upon delete success

### DIFF
--- a/src/plugins/handlers.js
+++ b/src/plugins/handlers.js
@@ -234,7 +234,10 @@ function handlers(app, opts, done){
 
     const dirpath = path.join('/', projectName);
 
-    workspace.deleteDirectory(dirpath);
+    workspace.deleteDirectory(dirpath)
+      .finally(function(){
+        showProjectsOverlay();
+      });
   }
 
   function deleteProjectConfirm(name){

--- a/src/plugins/notifications.js
+++ b/src/plugins/notifications.js
@@ -20,6 +20,7 @@ function notifications({ workspace, toast }, opts, done){
     DELETE_FILE_SUCCESS,
     DELETE_FILE_FAILURE,
     CHANGE_FILE_FAILURE,
+    DELETE_DIRECTORY_SUCCESS,
     DELETE_DIRECTORY_FAILURE,
     CHANGE_DIRECTORY_FAILURE
   } = workspace.STATUS_CONSTANTS;
@@ -30,6 +31,7 @@ function notifications({ workspace, toast }, opts, done){
     switch(status){
       case SAVE_FILE_SUCCESS:
       case DELETE_FILE_SUCCESS:
+      case DELETE_DIRECTORY_SUCCESS:
         toast.show(notification, { style: styles.successToast, timeout: 5000 });
         break;
       case SAVE_FILE_FAILURE:


### PR DESCRIPTION
#### What's this PR do?

Adds a `finally` statement to project deletion that always returns to the project overlay upon a deletion attempt (whether success or fail).  Also, adds a success toast upon successful deletion.
#### What are the important parts of the code?

Both files are important.
#### How should this be tested by the reviewer?

Add a project, try to delete it, click okay.  The project should be deleted and you should be returned to the project overlay.  There should also be a green toast behind the overlay saying the project was deleted successfully.
#### Is any other information necessary to understand this?

Behavior defined in #278
#### What are the relevant tickets? (Please add `closes`, `refs`, etc)

Fixes #278
