### PR TITLE
Automatic Reconnect on USB discovery

### DIFF
--- a/client.js
+++ b/client.js
@@ -94,9 +94,7 @@ function onRender(err){
     })
     .catch(console.error.bind(console));
 
-  chrome.usb.onDeviceAdded.addListener(function(device){
-    deviceAdded(device);
-  });
+  chrome.usb.onDeviceAdded.addListener(deviceAdded);
 }
 
 function onRegister(err){

--- a/client.js
+++ b/client.js
@@ -73,7 +73,8 @@ function onRender(err){
     newFile,
     showNewVersionOverlay,
     changeFile,
-    changeProject
+    changeProject,
+    deviceAdded
   } = handlers;
 
   // Finish Loading Plugin
@@ -92,6 +93,15 @@ function onRender(err){
       showNewVersionOverlay();
     })
     .catch(console.error.bind(console));
+
+  chrome.usb.onDeviceAdded.addListener(function(device){
+    console.log('device added: ', device);
+    deviceAdded(device);
+  });
+
+  chrome.usb.onDeviceRemoved.addListener(function(device){
+    console.log('device removed: ', device);
+  });
 }
 
 function onRegister(err){

--- a/client.js
+++ b/client.js
@@ -95,12 +95,7 @@ function onRender(err){
     .catch(console.error.bind(console));
 
   chrome.usb.onDeviceAdded.addListener(function(device){
-    console.log('device added: ', device);
     deviceAdded(device);
-  });
-
-  chrome.usb.onDeviceRemoved.addListener(function(device){
-    console.log('device removed: ', device);
   });
 }
 

--- a/client.js
+++ b/client.js
@@ -94,7 +94,9 @@ function onRender(err){
     })
     .catch(console.error.bind(console));
 
-  chrome.usb.onDeviceAdded.addListener(deviceAdded);
+  chrome.usb.onDeviceAdded.addListener(function(){
+    setTimeout(deviceAdded, 200);
+  });
 }
 
 function onRegister(err){

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,14 @@
     "serial",
     "unlimitedStorage",
     "syncFileSystem",
-    "storage"
+    "storage",
+    "usb",
+    {
+      "usbDevices": [
+        { "vendorId": 1027, "productId": 24577 },
+        { "vendorId": 1027, "productId": 24597 }
+      ]
+    }
   ],
   "icons": {
     "16": "icons/icon16.png",

--- a/src/plugins/handlers.js
+++ b/src/plugins/handlers.js
@@ -615,17 +615,15 @@ function handlers(app, opts, done){
     download();
   }
 
-  function deviceAdded(device){
+  function deviceAdded(){
     const { device } = store.getState();
-    const { content } = workspace.getState();
 
     const scanOpts = {
       reject: [
         /Bluetooth-Incoming-Port/,
         /Bluetooth-Modem/,
         /dev\/cu\./
-      ],
-      source: content
+      ]
     };
 
     app.scanBoards(scanOpts)
@@ -635,10 +633,12 @@ function handlers(app, opts, done){
           var board = app.getBoard(device.selected);
           if(board){
             board.removeListener('terminal', onTerminal);
+            board.removeListener('close', onClose);
             board.open()
               .then(function(){
                 connect();
                 board.on('terminal', onTerminal);
+                board.on('close', onClose);
               });
           }
         }

--- a/src/plugins/handlers.js
+++ b/src/plugins/handlers.js
@@ -634,9 +634,12 @@ function handlers(app, opts, done){
         if(device.selected && device.path && !device.connected && _.some(devices, 'path', device.selected.path)){
           var board = app.getBoard(device.selected);
           if(board){
-            console.log('opening', board);
-            board.open();
-            connect();
+            board.removeListener('terminal', onTerminal);
+            board.open()
+              .then(function(){
+                connect();
+                board.on('terminal', onTerminal);
+              });
           }
         }
       });

--- a/src/plugins/handlers.js
+++ b/src/plugins/handlers.js
@@ -615,6 +615,33 @@ function handlers(app, opts, done){
     download();
   }
 
+  function deviceAdded(device){
+    const { device } = store.getState();
+    const { content } = workspace.getState();
+
+    const scanOpts = {
+      reject: [
+        /Bluetooth-Incoming-Port/,
+        /Bluetooth-Modem/,
+        /dev\/cu\./
+      ],
+      source: content
+    };
+
+    app.scanBoards(scanOpts)
+      .then(function(devices){
+        store.dispatch(creators.updateDevices(devices));
+        if(device.selected && device.path && !device.connected && _.some(devices, 'path', device.selected.path)){
+          var board = app.getBoard(device.selected);
+          if(board){
+            console.log('opening', board);
+            board.open();
+            connect();
+          }
+        }
+      });
+  }
+
   function enableAutoDownload(){
     store.dispatch(creators.enableAutoDownload());
   }
@@ -672,7 +699,8 @@ function handlers(app, opts, done){
     download,
     toggleEcho,
     enableAutoDownload,
-    disableAutoDownload
+    disableAutoDownload,
+    deviceAdded
   });
 
   done();


### PR DESCRIPTION
#### What's this PR do?

This enables USB device detection, and automatically reconnects a recently-disconnected device if one is discovered. 
#### What are the important parts of the code?

The reconnect process is in the `deviceAdded` handler, and will only trigger if a device is selected and is available in the updated device list.
#### How should this be tested by the reviewer?

Unplug the device after bootload, then reconnect. Verify terminal output resumes as normal. Note: Reconnecting the device will reboot the board, causing any output to start from the beginning.
#### What are the relevant tickets?

Closes #79 
Depends on irkenjs/bs2-serial-protocol/pull/18
