### PR TITLE
Card component

### DIFF
--- a/src/components/card.js
+++ b/src/components/card.js
@@ -13,11 +13,11 @@ const defaultStyle = {
 class Card extends React.Component {
   render(){
     const {
-      style,
+      style = {},
       children
     } = this.props;
 
-    const styles = _.assign(defaultStyle, style || {});
+    const styles = _.assign({}, defaultStyle, style);
 
     return (
       <div style={styles}>

--- a/src/components/card.js
+++ b/src/components/card.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const _ = require('lodash');
+const React = require('react');
+
+const defaultStyle = {
+  boxShadow: '0 2px 2px 0 rgba(0,0,0,.14),0 3px 1px -2px rgba(0,0,0,.2),0 1px 5px 0 rgba(0,0,0,.12)',
+  backgroundColor: 'white',
+  padding: '16px',
+  borderRadius: '2px'
+};
+
+class Card extends React.Component {
+  render(){
+    const {
+      style,
+      children
+    } = this.props;
+
+    const styles = _.assign(defaultStyle, style || {});
+
+    return (
+      <div style={styles}>
+        {children}
+      </div>
+    );
+  }
+}
+
+module.exports = Card;

--- a/src/components/overlay.js
+++ b/src/components/overlay.js
@@ -2,7 +2,8 @@
 
 const _ = require('lodash');
 const React = require('react');
-const Card = require('react-material/components/Card');
+
+const Card = require('./card');
 
 const styles = {
   overlay: {
@@ -31,7 +32,7 @@ class Overlay extends React.Component {
     }
 
     return (
-      <Card styles={cardStyle}>
+      <Card style={cardStyle}>
         {children}
       </Card>
     );

--- a/src/components/projects-button.js
+++ b/src/components/projects-button.js
@@ -6,10 +6,9 @@ const { MainButton } = require('react-mfb-iceddev');
 const styles = {
   changeFolderButton: {
     position: 'absolute',
-    top: -28,
+    top: 28,
     margin: 0,
-    right: 19,
-    left: 'auto',
+    left: 140,
     transform: 'none'
   }
 };

--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const React = require('react');
-const Card = require('react-material/components/Card');
+
+const Card = require('./card');
 
 const styles = {
   card: {
@@ -20,7 +21,7 @@ class Sidebar extends React.Component {
     } = this.props;
 
     return (
-      <Card styles={styles.card}>
+      <Card style={styles.card}>
         {children}
       </Card>
     );

--- a/src/views/download-overlay.js
+++ b/src/views/download-overlay.js
@@ -14,7 +14,9 @@ const ProgressBar = require('../components/progress-bar');
 const styles = {
   overlay: {
     paddingBottom: 40,
-    width: 600
+    width: 600,
+    // keep the download progress pinned to the bottom
+    position: 'relative'
   },
   overlayFooter: {
     marginLeft: 0,


### PR DESCRIPTION
#### What's this PR do?

Adds a custom `Card` component instead of using the one provided by react-material, which had some styling that caused scrollbars to not be clickable.  This custom one has only the bare minimum styling.  The shadow on the edge of the custom card may be less pronounced because the react-material library was using a bunch of elements to generate its shadow.
#### What are the important parts of the code?

`src/components/card.js` has the definition of the custom `Card` component, it is then swapped out in 
`src/components/overlay.js` and `src/components/sidebar.js`.  Changes were also made to `src/components/projects-button.js` because we no longer have `postition: relative` on the card component to contain it (again, because we only want the minimum styles).
#### How should this be tested by the reviewer?
1. Create files in the sidebar until they exceed the boundaries.  Verify that you can grab and drag the scrollbar (this is a bit difficult on OSX).
2. Create projects (in the project view) until they exceed the boundaries.  Verify that you can grab and drag the scrollbar (this is a bit difficult on OSX).
3. Verify the visual look of the sidebar and modals look similar to the old implementation.
4. Verify all modals still behave properly.
#### Is any other information necessary to understand this?

Everything should be outlined above.
#### What are the relevant tickets? (Please add `closes`, `refs`, etc)

Fixes #277 
Fixes #290 
#### Screenshots (if appropriate)

Very hard to capture this on OSX :disappointed: 
