### PR TITLE
display correct messages based on number of (matching) stamps plugged in

### DIFF
--- a/src/plugins/handlers.js
+++ b/src/plugins/handlers.js
@@ -553,20 +553,27 @@ function handlers(app, opts, done){
     const { deviceList } = store.getState();
     const { none, noneMatched, multiple } = messages;
 
-    const hasMatch = _.some(deviceList, { match: true });
-    const matchedDevices = _.filter(deviceList, ({ match, name }) => match && name);
+    const typeMatches = _.filter(deviceList, ({ name, type }) => name && (type === 'bs2'));
+    const exactMatches = _.filter(deviceList, ({ match, name }) => match && name);
 
-    if (!hasMatch) {
-      store.dispatch(creators.updateSearchStatus(none));
-    } else if (matchedDevices.length === 0) {
-      store.dispatch(creators.updateSearchStatus(noneMatched));
-    } else if(matchedDevices.length === 1) {
+    if(exactMatches.length === 1){
       store.dispatch(creators.clearSearchStatus());
-      store.dispatch(creators.updateSelectedDevice(matchedDevices[0]));
+      store.dispatch(creators.updateSelectedDevice(exactMatches[0]));
       download();
-    } else {
-      store.dispatch(creators.updateSearchStatus(multiple));
+      return;
     }
+
+    if(exactMatches.length > 1){
+      store.dispatch(creators.updateSearchStatus(multiple));
+      return;
+    }
+
+    if(typeMatches.length > 0 && exactMatches.length === 0){
+      store.dispatch(creators.updateSearchStatus(noneMatched));
+      return;
+    }
+
+    store.dispatch(creators.updateSearchStatus(none));
   }
 
   function reloadDevices(){


### PR DESCRIPTION
#### What's this PR do?

Refactors the code that displays the messages based on the number of Basic Stamps (and matching ones) when attempting a download.
#### What are the important parts of the code?

All the logic happens in the `checkAutoDownload` function of `src/plugins/handlers.js`
#### How should this be tested by the reviewer?

There's actually a bunch of cases to test here.  I will outline all that I know about.
1. Plug in 1 Stamp that matches the directive in your code. Attempt to download.  No message should show up, download should start immediately.
2. Plug in 1 Stamp that matches and 1 that doesn't match the directive in your code. Attempt to download. No message should show up, download should start immediately.
3. Plug in 2 Stamps that match the directive in your code. Attempt to download. The message "Please select which module to download to." should appear.
4. Plug in 1 Stamp that doesn't match the directive in your code. Attempt to download. The message "No matching BASIC Stamps found." should appear.
5. Remove all Stamps. Attempt to download. The message "No BASIC Stamps found." should appear.
#### Is any other information necessary to understand this?

I don't think so.
#### What are the relevant tickets? (Please add `closes`, `refs`, etc)

Closes #311
#### Screenshots (if appropriate)

![screen shot 2015-10-29 at 12 47 33 pm](https://cloud.githubusercontent.com/assets/992373/10830175/823ebd54-7e3b-11e5-9cd8-d8df47670f33.png)
![screen shot 2015-10-29 at 12 47 52 pm](https://cloud.githubusercontent.com/assets/992373/10830176/824f7626-7e3b-11e5-9d9a-cac2b710cd9d.png)
![screen shot 2015-10-29 at 12 48 06 pm](https://cloud.githubusercontent.com/assets/992373/10830177/8254ca9a-7e3b-11e5-83f2-4d43d2b824ee.png)
![screen shot 2015-10-29 at 12 48 17 pm](https://cloud.githubusercontent.com/assets/992373/10830178/8257cf56-7e3b-11e5-8cda-84fd599dfce2.png)
