### PR TITLE
Fix TX flash on transmit text

### DIFF
--- a/src/plugins/handlers.js
+++ b/src/plugins/handlers.js
@@ -520,6 +520,10 @@ function handlers(app, opts, done){
     txOn();
   }
 
+  function onTransmit(){
+    txOn();
+  }
+
   function toggleEcho(){
     const { device } = store.getState();
     const { echo } = consoleStore.getState();
@@ -548,6 +552,7 @@ function handlers(app, opts, done){
     const board = app.getBoard(selected);
 
     // safety remove attempt for progress
+    board.removeListener('transmit', onTransmit);
     board.removeListener('progress', onProgress);
     board.removeListener('terminal', onTerminal);
     board.removeListener('close', onClose);
@@ -559,6 +564,7 @@ function handlers(app, opts, done){
         clearTerminal();
         board.on('terminal', onTerminal);
         board.on('close', onClose);
+        board.on('transmit', onTransmit);
         toast.clear();
 
         toast.show(`'${filename}' downloaded successfully`, successToastOpts);


### PR DESCRIPTION
#### What's this PR do?

This PR fixes an issue where transmitting text would not flash the TX status light.
#### How should this be tested by the reviewer?

Download any program, send data via the transmit pane. Verify that the TX flash occurs, and an RX flash will also occur due to hardware echo. 
#### Is any other information necessary to understand this?

The transmit event was not being bound to the TX flash callback after the download process finished
#### What are the relevant tickets?

Closes #310 
